### PR TITLE
Wandering Cubes - Reduce markup

### DIFF
--- a/4-wandering-cubes.html
+++ b/4-wandering-cubes.html
@@ -9,7 +9,8 @@
       position: relative;
     }
 
-    .cube1, .cube2 {
+    .spinner:before, .spinner:after {
+      content: '';
       background-color: #333;
       width: 10px;
       height: 10px;
@@ -21,7 +22,7 @@
       animation: cubemove 1.8s infinite ease-in-out;
     }
 
-    .cube2 {
+    .spinner:after {
       -webkit-animation-delay: -0.9s;
       animation-delay: -0.9s;
     }
@@ -55,9 +56,6 @@
     </style>
   </head>
   <body>
-    <div class="spinner">
-      <div class="cube1"></div>
-      <div class="cube2"></div>
-    </div>
+    <div class="spinner"></div>
   </body>
 </html>


### PR DESCRIPTION
Every browser that supports CSS animations also supports :before and :after pseudo-elements. So to avoid unnecessary markup we can remove the inner divs and use these elements instead. Pull request follows. Tested in 5 different browsers and it is working fine.
