### PR TITLE
Update to current component version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "SpinKit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "homepage": "https://github.com/tobiasahlin/SpinKit",
   "authors": [
     "Tobias Ahlin"


### PR DESCRIPTION
Fixing bower warning:

```
bower info SpinKit
```

```
bower mismatch      Version declared in the json (1.0.0) is different than the resolved one (1.0.1)
bower resolved      git://github.com/tobiasahlin/SpinKit.git#1.0.1
```