### PR TITLE
Fix three bounce for Android

### DIFF
--- a/css/spinkit.css
+++ b/css/spinkit.css
@@ -311,8 +311,8 @@
     background-color: #333;
     border-radius: 100%;
     display: inline-block;
-    -webkit-animation: sk-threeBounceDelay 1.4s infinite ease-in-out both;
-            animation: sk-threeBounceDelay 1.4s infinite ease-in-out both; }
+    -webkit-animation: sk-three-bounce 1.4s ease-in-out 0s infinite both;
+            animation: sk-three-bounce 1.4s ease-in-out 0s infinite both; }
   .sk-three-bounce .sk-bounce1 {
     -webkit-animation-delay: -0.32s;
             animation-delay: -0.32s; }
@@ -320,7 +320,7 @@
     -webkit-animation-delay: -0.16s;
             animation-delay: -0.16s; }
 
-@-webkit-keyframes sk-threeBounceDelay {
+@-webkit-keyframes sk-three-bounce {
   0%, 80%, 100% {
     -webkit-transform: scale(0);
             transform: scale(0); }
@@ -328,7 +328,7 @@
     -webkit-transform: scale(1);
             transform: scale(1); } }
 
-@keyframes sk-threeBounceDelay {
+@keyframes sk-three-bounce {
   0%, 80%, 100% {
     -webkit-transform: scale(0);
             transform: scale(0); }

--- a/css/spinners/7-three-bounce.css
+++ b/css/spinners/7-three-bounce.css
@@ -18,8 +18,8 @@
     background-color: #333;
     border-radius: 100%;
     display: inline-block;
-    -webkit-animation: sk-threeBounceDelay 1.4s infinite ease-in-out both;
-            animation: sk-threeBounceDelay 1.4s infinite ease-in-out both; }
+    -webkit-animation: sk-three-bounce 1.4s ease-in-out 0s infinite both;
+            animation: sk-three-bounce 1.4s ease-in-out 0s infinite both; }
   .sk-three-bounce .sk-bounce1 {
     -webkit-animation-delay: -0.32s;
             animation-delay: -0.32s; }
@@ -27,7 +27,7 @@
     -webkit-animation-delay: -0.16s;
             animation-delay: -0.16s; }
 
-@-webkit-keyframes sk-threeBounceDelay {
+@-webkit-keyframes sk-three-bounce {
   0%, 80%, 100% {
     -webkit-transform: scale(0);
             transform: scale(0); }
@@ -35,7 +35,7 @@
     -webkit-transform: scale(1);
             transform: scale(1); } }
 
-@keyframes sk-threeBounceDelay {
+@keyframes sk-three-bounce {
   0%, 80%, 100% {
     -webkit-transform: scale(0);
             transform: scale(0); }

--- a/examples/7-three-bounce.html
+++ b/examples/7-three-bounce.html
@@ -23,8 +23,8 @@
     background-color: #333;
     border-radius: 100%;
     display: inline-block;
-    -webkit-animation: sk-threeBounceDelay 1.4s infinite ease-in-out both;
-            animation: sk-threeBounceDelay 1.4s infinite ease-in-out both; }
+    -webkit-animation: sk-three-bounce 1.4s ease-in-out 0s infinite both;
+            animation: sk-three-bounce 1.4s ease-in-out 0s infinite both; }
   .sk-three-bounce .sk-bounce1 {
     -webkit-animation-delay: -0.32s;
             animation-delay: -0.32s; }
@@ -32,7 +32,7 @@
     -webkit-animation-delay: -0.16s;
             animation-delay: -0.16s; }
 
-@-webkit-keyframes sk-threeBounceDelay {
+@-webkit-keyframes sk-three-bounce {
   0%, 80%, 100% {
     -webkit-transform: scale(0);
             transform: scale(0); }
@@ -40,7 +40,7 @@
     -webkit-transform: scale(1);
             transform: scale(1); } }
 
-@keyframes sk-threeBounceDelay {
+@keyframes sk-three-bounce {
   0%, 80%, 100% {
     -webkit-transform: scale(0);
             transform: scale(0); }

--- a/scss/spinners/7-three-bounce.scss
+++ b/scss/spinners/7-three-bounce.scss
@@ -11,6 +11,8 @@
  @import "../variables";
 
 .sk-three-bounce {
+  $animationDuration: 1.4s;
+  $delayRange: 0.32s;
   margin: $spinkit-spinner-margin;
   width: 70px;
   text-align: center;
@@ -22,19 +24,14 @@
 
     border-radius: 100%;
     display: inline-block;
-    animation: sk-threeBounceDelay 1.4s infinite ease-in-out both;
+    animation: sk-three-bounce $animationDuration ease-in-out 0s infinite both;
   }
 
-  .sk-bounce1 {
-    animation-delay: -0.32s;
-  }
-
-  .sk-bounce2 {
-    animation-delay: -0.16s;
-  }
+  .sk-bounce1 { animation-delay: -$delayRange; }
+  .sk-bounce2 { animation-delay: -$delayRange / 2; }
 }
 
-@keyframes sk-threeBounceDelay {
+@keyframes sk-three-bounce {
   0%, 80%, 100% {
     transform: scale(0);
   } 40% {


### PR DESCRIPTION
Fixes #30

Another blind fix, by explicitly setting the delay to 0 for the third spinner, and correctly ordering the shorthand attributes.