### PR TITLE
Fix cube dimensions

### DIFF
--- a/css/spinkit.css
+++ b/css/spinkit.css
@@ -503,8 +503,8 @@
    * 7 8 9
    */ }
   .sk-cube-grid .sk-cube {
-    width: 33%;
-    height: 33%;
+    width: 33.33%;
+    height: 33.33%;
     background-color: #333;
     float: left;
     -webkit-animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;


### PR DESCRIPTION
Hello,
on retina displays, this becomes important when the spinner is bigger than ~40px.

Cheers!