### PR TITLE
Add classes to allow for changing the size and margin of the spinners

### DIFF
--- a/css/spinkit.css
+++ b/css/spinkit.css
@@ -1,14 +1,97 @@
 /*
  *  Usage:
  *
-      <div class="sk-rotating-plane"></div>
+      <div class="sk sk-rotating-plane"></div>
  *
  */
-.sk-rotating-plane {
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-rotating-plane {
   background-color: #333;
-  margin: 40px auto;
   -webkit-animation: sk-rotatePlane 1.2s infinite ease-in-out;
           animation: sk-rotatePlane 1.2s infinite ease-in-out; }
 
@@ -37,18 +120,101 @@
 /*
  *  Usage:
  *
-      <div class="sk-double-bounce">
+      <div class="sk sk-double-bounce">
         <div class="sk-child sk-double-bounce1"></div>
         <div class="sk-child sk-double-bounce2"></div>
       </div>
  *
  */
-.sk-double-bounce {
-  width: 40px;
-  height: 40px;
-  position: relative;
-  margin: 40px auto; }
-  .sk-double-bounce .sk-child {
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-double-bounce {
+  position: relative; }
+  .sk.sk-double-bounce .sk-child {
     width: 100%;
     height: 100%;
     border-radius: 50%;
@@ -57,9 +223,9 @@
     position: absolute;
     top: 0;
     left: 0;
-    -webkit-animation: sk-doubleBounce 2s infinite ease-in-out;
-            animation: sk-doubleBounce 2s infinite ease-in-out; }
-  .sk-double-bounce .sk-double-bounce2 {
+    -webkit-animation: sk-doubleBounce 2.0s infinite ease-in-out;
+            animation: sk-doubleBounce 2.0s infinite ease-in-out; }
+  .sk.sk-double-bounce .sk-double-bounce2 {
     -webkit-animation-delay: -1.0s;
             animation-delay: -1.0s; }
 
@@ -82,7 +248,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-wave">
+      <div class="sk sk-wave">
         <div class="sk-rect sk-rect1"></div>
         <div class="sk-rect sk-rect2"></div>
         <div class="sk-rect sk-rect3"></div>
@@ -91,32 +257,140 @@
       </div>
  *
  */
-.sk-wave {
-  margin: 40px auto;
-  width: 50px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-wave {
   text-align: center;
   font-size: 10px; }
-  .sk-wave .sk-rect {
+  .sk.sk-wave .sk-rect {
     background-color: #333;
     height: 100%;
     width: 6px;
     display: inline-block;
     -webkit-animation: sk-waveStretchDelay 1.2s infinite ease-in-out;
             animation: sk-waveStretchDelay 1.2s infinite ease-in-out; }
-  .sk-wave .sk-rect1 {
+  .sk.sk-wave.sk-xs-width, .sk.sk-wave.sk-xs {
+    width: 12.5px;
+    font-size: 2.5px; }
+    .sk.sk-wave.sk-xs-width .sk-rect, .sk.sk-wave.sk-xs .sk-rect {
+      width: 1.5px; }
+  .sk.sk-wave.sk-sm-width, .sk.sk-wave.sk-sm {
+    width: 25px;
+    font-size: 5px; }
+    .sk.sk-wave.sk-sm-width .sk-rect, .sk.sk-wave.sk-sm .sk-rect {
+      width: 3px; }
+  .sk.sk-wave.sk-md-width, .sk.sk-wave.sk-md {
+    width: 50px;
+    font-size: 10px; }
+    .sk.sk-wave.sk-md-width .sk-rect, .sk.sk-wave.sk-md .sk-rect {
+      width: 6px; }
+  .sk.sk-wave.sk-lg-width, .sk.sk-wave.sk-lg {
+    width: 75px;
+    font-size: 15px; }
+    .sk.sk-wave.sk-lg-width .sk-rect, .sk.sk-wave.sk-lg .sk-rect {
+      width: 9px; }
+  .sk.sk-wave.sk-xl-width, .sk.sk-wave.sk-xl {
+    width: 125px;
+    font-size: 25px; }
+    .sk.sk-wave.sk-xl-width .sk-rect, .sk.sk-wave.sk-xl .sk-rect {
+      width: 15px; }
+  .sk.sk-wave .sk-rect1 {
     -webkit-animation-delay: -1.2s;
             animation-delay: -1.2s; }
-  .sk-wave .sk-rect2 {
+  .sk.sk-wave .sk-rect2 {
     -webkit-animation-delay: -1.1s;
             animation-delay: -1.1s; }
-  .sk-wave .sk-rect3 {
+  .sk.sk-wave .sk-rect3 {
     -webkit-animation-delay: -1s;
             animation-delay: -1s; }
-  .sk-wave .sk-rect4 {
+  .sk.sk-wave .sk-rect4 {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
-  .sk-wave .sk-rect5 {
+  .sk.sk-wave .sk-rect5 {
     -webkit-animation-delay: -0.8s;
             animation-delay: -0.8s; }
 
@@ -139,18 +413,101 @@
 /*
  *  Usage:
  *
-      <div class="sk-wandering-cubes">
+      <div class="sk sk-wandering-cubes">
         <div class="sk-cube sk-cube1"></div>
         <div class="sk-cube sk-cube2"></div>
       </div>
  *
  */
-.sk-wandering-cubes {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-wandering-cubes {
   position: relative; }
-  .sk-wandering-cubes .sk-cube {
+  .sk.sk-wandering-cubes .sk-cube {
     background-color: #333;
     width: 10px;
     height: 10px;
@@ -159,9 +516,24 @@
     left: 0;
     -webkit-animation: sk-wanderingCube 1.8s ease-in-out -1.8s infinite both;
             animation: sk-wanderingCube 1.8s ease-in-out -1.8s infinite both; }
-  .sk-wandering-cubes .sk-cube2 {
+  .sk.sk-wandering-cubes .sk-cube2 {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
+  .sk.sk-wandering-cubes.sk-xs-width, .sk.sk-wandering-cubes.sk-xs {
+    width: 2.5px;
+    height: 2.5px; }
+  .sk.sk-wandering-cubes.sk-sm-width, .sk.sk-wandering-cubes.sk-sm {
+    width: 5px;
+    height: 5px; }
+  .sk.sk-wandering-cubes.sk-md-width, .sk.sk-wandering-cubes.sk-md {
+    width: 10px;
+    height: 10px; }
+  .sk.sk-wandering-cubes.sk-lg-width, .sk.sk-wandering-cubes.sk-lg {
+    width: 15px;
+    height: 15px; }
+  .sk.sk-wandering-cubes.sk-xl-width, .sk.sk-wandering-cubes.sk-xl {
+    width: 25px;
+    height: 25px; }
 
 @-webkit-keyframes sk-wanderingCube {
   0% {
@@ -208,17 +580,100 @@
 /*
  *  Usage:
  *
-      <div class="sk-spinner sk-spinner-pulse"></div>
+      <div class="sk sk-pulse"></div>
  *
  */
-.sk-spinner-pulse {
-  width: 40px;
-  height: 40px;
-  margin: 40px auto;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-pulse {
   background-color: #333;
   border-radius: 100%;
-  -webkit-animation: sk-pulseScaleOut 1s infinite ease-in-out;
-          animation: sk-pulseScaleOut 1s infinite ease-in-out; }
+  -webkit-animation: sk-pulseScaleOut 1.0s infinite ease-in-out;
+          animation: sk-pulseScaleOut 1.0s infinite ease-in-out; }
 
 @-webkit-keyframes sk-pulseScaleOut {
   0% {
@@ -241,21 +696,104 @@
 /*
  *  Usage:
  *
-      <div class="sk-chasing-dots">
+      <div class="sk sk-chasing-dots">
         <div class="sk-child sk-dot1"></div>
         <div class="sk-child sk-dot2"></div>
       </div>
  *
  */
-.sk-chasing-dots {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-chasing-dots {
   position: relative;
   text-align: center;
   -webkit-animation: sk-chasingDotsRotate 2s infinite linear;
           animation: sk-chasingDotsRotate 2s infinite linear; }
-  .sk-chasing-dots .sk-child {
+  .sk.sk-chasing-dots .sk-child {
     width: 60%;
     height: 60%;
     display: inline-block;
@@ -265,7 +803,7 @@
     border-radius: 100%;
     -webkit-animation: sk-chasingDotsBounce 2s infinite ease-in-out;
             animation: sk-chasingDotsBounce 2s infinite ease-in-out; }
-  .sk-chasing-dots .sk-dot2 {
+  .sk.sk-chasing-dots .sk-dot2 {
     top: auto;
     bottom: 0;
     -webkit-animation-delay: -1s;
@@ -300,18 +838,103 @@
 /*
  *  Usage:
  *
-      <div class="sk-three-bounce">
+      <div class="sk sk-three-bounce">
         <div class="sk-child sk-bounce1"></div>
         <div class="sk-child sk-bounce2"></div>
         <div class="sk-child sk-bounce3"></div>
       </div>
  *
  */
-.sk-three-bounce {
-  margin: 40px auto;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-three-bounce {
   width: 80px;
   text-align: center; }
-  .sk-three-bounce .sk-child {
+  .sk.sk-three-bounce .sk-child {
     width: 20px;
     height: 20px;
     background-color: #333;
@@ -319,10 +942,35 @@
     display: inline-block;
     -webkit-animation: sk-three-bounce 1.4s ease-in-out 0s infinite both;
             animation: sk-three-bounce 1.4s ease-in-out 0s infinite both; }
-  .sk-three-bounce .sk-bounce1 {
+  .sk.sk-three-bounce.sk-xs-width, .sk.sk-three-bounce.sk-xs {
+    width: 25px; }
+    .sk.sk-three-bounce.sk-xs-width .sk-child, .sk.sk-three-bounce.sk-xs .sk-child {
+      width: 4px;
+      height: 4px; }
+  .sk.sk-three-bounce.sk-sm-width, .sk.sk-three-bounce.sk-sm {
+    width: 40px; }
+    .sk.sk-three-bounce.sk-sm-width .sk-child, .sk.sk-three-bounce.sk-sm .sk-child {
+      width: 10px;
+      height: 10px; }
+  .sk.sk-three-bounce.sk-md-width, .sk.sk-three-bounce.sk-md {
+    width: 80px; }
+    .sk.sk-three-bounce.sk-md-width .sk-child, .sk.sk-three-bounce.sk-md .sk-child {
+      width: 20px;
+      height: 20px; }
+  .sk.sk-three-bounce.sk-lg-width, .sk.sk-three-bounce.sk-lg {
+    width: 120px; }
+    .sk.sk-three-bounce.sk-lg-width .sk-child, .sk.sk-three-bounce.sk-lg .sk-child {
+      width: 30px;
+      height: 30px; }
+  .sk.sk-three-bounce.sk-xl-width, .sk.sk-three-bounce.sk-xl {
+    width: 200px; }
+    .sk.sk-three-bounce.sk-xl-width .sk-child, .sk.sk-three-bounce.sk-xl .sk-child {
+      width: 50px;
+      height: 50px; }
+  .sk.sk-three-bounce .sk-bounce1 {
     -webkit-animation-delay: -0.32s;
             animation-delay: -0.32s; }
-  .sk-three-bounce .sk-bounce2 {
+  .sk.sk-three-bounce .sk-bounce2 {
     -webkit-animation-delay: -0.16s;
             animation-delay: -0.16s; }
 
@@ -345,7 +993,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-circle">
+      <div class="sk sk-circle">
         <div class="sk-circle1 sk-child"></div>
         <div class="sk-circle2 sk-child"></div>
         <div class="sk-circle3 sk-child"></div>
@@ -361,18 +1009,101 @@
       </div>
  *
  */
-.sk-circle {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-circle {
   position: relative; }
-  .sk-circle .sk-child {
+  .sk.sk-circle .sk-child {
     width: 100%;
     height: 100%;
     position: absolute;
     left: 0;
     top: 0; }
-  .sk-circle .sk-child:before {
+  .sk.sk-circle .sk-child:before {
     content: '';
     display: block;
     margin: 0 auto;
@@ -382,81 +1113,81 @@
     border-radius: 100%;
     -webkit-animation: sk-circleBounceDelay 1.2s infinite ease-in-out both;
             animation: sk-circleBounceDelay 1.2s infinite ease-in-out both; }
-  .sk-circle .sk-circle2 {
+  .sk.sk-circle .sk-circle2 {
     -webkit-transform: rotate(30deg);
         -ms-transform: rotate(30deg);
             transform: rotate(30deg); }
-  .sk-circle .sk-circle3 {
+  .sk.sk-circle .sk-circle3 {
     -webkit-transform: rotate(60deg);
         -ms-transform: rotate(60deg);
             transform: rotate(60deg); }
-  .sk-circle .sk-circle4 {
+  .sk.sk-circle .sk-circle4 {
     -webkit-transform: rotate(90deg);
         -ms-transform: rotate(90deg);
             transform: rotate(90deg); }
-  .sk-circle .sk-circle5 {
+  .sk.sk-circle .sk-circle5 {
     -webkit-transform: rotate(120deg);
         -ms-transform: rotate(120deg);
             transform: rotate(120deg); }
-  .sk-circle .sk-circle6 {
+  .sk.sk-circle .sk-circle6 {
     -webkit-transform: rotate(150deg);
         -ms-transform: rotate(150deg);
             transform: rotate(150deg); }
-  .sk-circle .sk-circle7 {
+  .sk.sk-circle .sk-circle7 {
     -webkit-transform: rotate(180deg);
         -ms-transform: rotate(180deg);
             transform: rotate(180deg); }
-  .sk-circle .sk-circle8 {
+  .sk.sk-circle .sk-circle8 {
     -webkit-transform: rotate(210deg);
         -ms-transform: rotate(210deg);
             transform: rotate(210deg); }
-  .sk-circle .sk-circle9 {
+  .sk.sk-circle .sk-circle9 {
     -webkit-transform: rotate(240deg);
         -ms-transform: rotate(240deg);
             transform: rotate(240deg); }
-  .sk-circle .sk-circle10 {
+  .sk.sk-circle .sk-circle10 {
     -webkit-transform: rotate(270deg);
         -ms-transform: rotate(270deg);
             transform: rotate(270deg); }
-  .sk-circle .sk-circle11 {
+  .sk.sk-circle .sk-circle11 {
     -webkit-transform: rotate(300deg);
         -ms-transform: rotate(300deg);
             transform: rotate(300deg); }
-  .sk-circle .sk-circle12 {
+  .sk.sk-circle .sk-circle12 {
     -webkit-transform: rotate(330deg);
         -ms-transform: rotate(330deg);
             transform: rotate(330deg); }
-  .sk-circle .sk-circle2:before {
+  .sk.sk-circle .sk-circle2:before {
     -webkit-animation-delay: -1.1s;
             animation-delay: -1.1s; }
-  .sk-circle .sk-circle3:before {
+  .sk.sk-circle .sk-circle3:before {
     -webkit-animation-delay: -1s;
             animation-delay: -1s; }
-  .sk-circle .sk-circle4:before {
+  .sk.sk-circle .sk-circle4:before {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
-  .sk-circle .sk-circle5:before {
+  .sk.sk-circle .sk-circle5:before {
     -webkit-animation-delay: -0.8s;
             animation-delay: -0.8s; }
-  .sk-circle .sk-circle6:before {
+  .sk.sk-circle .sk-circle6:before {
     -webkit-animation-delay: -0.7s;
             animation-delay: -0.7s; }
-  .sk-circle .sk-circle7:before {
+  .sk.sk-circle .sk-circle7:before {
     -webkit-animation-delay: -0.6s;
             animation-delay: -0.6s; }
-  .sk-circle .sk-circle8:before {
+  .sk.sk-circle .sk-circle8:before {
     -webkit-animation-delay: -0.5s;
             animation-delay: -0.5s; }
-  .sk-circle .sk-circle9:before {
+  .sk.sk-circle .sk-circle9:before {
     -webkit-animation-delay: -0.4s;
             animation-delay: -0.4s; }
-  .sk-circle .sk-circle10:before {
+  .sk.sk-circle .sk-circle10:before {
     -webkit-animation-delay: -0.3s;
             animation-delay: -0.3s; }
-  .sk-circle .sk-circle11:before {
+  .sk.sk-circle .sk-circle11:before {
     -webkit-animation-delay: -0.2s;
             animation-delay: -0.2s; }
-  .sk-circle .sk-circle12:before {
+  .sk.sk-circle .sk-circle12:before {
     -webkit-animation-delay: -0.1s;
             animation-delay: -0.1s; }
 
@@ -479,7 +1210,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-cube-grid">
+      <div class="sk sk-cube-grid">
         <div class="sk-cube sk-cube1"></div>
         <div class="sk-cube sk-cube2"></div>
         <div class="sk-cube sk-cube3"></div>
@@ -492,48 +1223,131 @@
       </div>
  *
  */
-.sk-cube-grid {
-  width: 40px;
-  height: 40px;
-  margin: 40px auto;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-cube-grid {
   /*
    * Spinner positions
    * 1 2 3
    * 4 5 6
    * 7 8 9
    */ }
-  .sk-cube-grid .sk-cube {
+  .sk.sk-cube-grid .sk-cube {
     width: 33.33%;
     height: 33.33%;
     background-color: #333;
     float: left;
     -webkit-animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
             animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out; }
-  .sk-cube-grid .sk-cube1 {
+  .sk.sk-cube-grid .sk-cube1 {
     -webkit-animation-delay: 0.2s;
             animation-delay: 0.2s; }
-  .sk-cube-grid .sk-cube2 {
+  .sk.sk-cube-grid .sk-cube2 {
     -webkit-animation-delay: 0.3s;
             animation-delay: 0.3s; }
-  .sk-cube-grid .sk-cube3 {
+  .sk.sk-cube-grid .sk-cube3 {
     -webkit-animation-delay: 0.4s;
             animation-delay: 0.4s; }
-  .sk-cube-grid .sk-cube4 {
+  .sk.sk-cube-grid .sk-cube4 {
     -webkit-animation-delay: 0.1s;
             animation-delay: 0.1s; }
-  .sk-cube-grid .sk-cube5 {
+  .sk.sk-cube-grid .sk-cube5 {
     -webkit-animation-delay: 0.2s;
             animation-delay: 0.2s; }
-  .sk-cube-grid .sk-cube6 {
+  .sk.sk-cube-grid .sk-cube6 {
     -webkit-animation-delay: 0.3s;
             animation-delay: 0.3s; }
-  .sk-cube-grid .sk-cube7 {
+  .sk.sk-cube-grid .sk-cube7 {
     -webkit-animation-delay: 0.0s;
             animation-delay: 0.0s; }
-  .sk-cube-grid .sk-cube8 {
+  .sk.sk-cube-grid .sk-cube8 {
     -webkit-animation-delay: 0.1s;
             animation-delay: 0.1s; }
-  .sk-cube-grid .sk-cube9 {
+  .sk.sk-cube-grid .sk-cube9 {
     -webkit-animation-delay: 0.2s;
             animation-delay: 0.2s; }
 
@@ -556,7 +1370,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-fading-circle">
+      <div class="sk sk-fading-circle">
         <div class="sk-circle1 sk-circle"></div>
         <div class="sk-circle2 sk-circle"></div>
         <div class="sk-circle3 sk-circle"></div>
@@ -572,18 +1386,101 @@
       </div>
  *
  */
-.sk-fading-circle {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-fading-circle {
   position: relative; }
-  .sk-fading-circle .sk-circle {
+  .sk.sk-fading-circle .sk-circle {
     width: 100%;
     height: 100%;
     position: absolute;
     left: 0;
     top: 0; }
-  .sk-fading-circle .sk-circle:before {
+  .sk.sk-fading-circle .sk-circle:before {
     content: '';
     display: block;
     margin: 0 auto;
@@ -593,81 +1490,81 @@
     border-radius: 100%;
     -webkit-animation: sk-circleFadeDelay 1.2s infinite ease-in-out both;
             animation: sk-circleFadeDelay 1.2s infinite ease-in-out both; }
-  .sk-fading-circle .sk-circle2 {
+  .sk.sk-fading-circle .sk-circle2 {
     -webkit-transform: rotate(30deg);
         -ms-transform: rotate(30deg);
             transform: rotate(30deg); }
-  .sk-fading-circle .sk-circle3 {
+  .sk.sk-fading-circle .sk-circle3 {
     -webkit-transform: rotate(60deg);
         -ms-transform: rotate(60deg);
             transform: rotate(60deg); }
-  .sk-fading-circle .sk-circle4 {
+  .sk.sk-fading-circle .sk-circle4 {
     -webkit-transform: rotate(90deg);
         -ms-transform: rotate(90deg);
             transform: rotate(90deg); }
-  .sk-fading-circle .sk-circle5 {
+  .sk.sk-fading-circle .sk-circle5 {
     -webkit-transform: rotate(120deg);
         -ms-transform: rotate(120deg);
             transform: rotate(120deg); }
-  .sk-fading-circle .sk-circle6 {
+  .sk.sk-fading-circle .sk-circle6 {
     -webkit-transform: rotate(150deg);
         -ms-transform: rotate(150deg);
             transform: rotate(150deg); }
-  .sk-fading-circle .sk-circle7 {
+  .sk.sk-fading-circle .sk-circle7 {
     -webkit-transform: rotate(180deg);
         -ms-transform: rotate(180deg);
             transform: rotate(180deg); }
-  .sk-fading-circle .sk-circle8 {
+  .sk.sk-fading-circle .sk-circle8 {
     -webkit-transform: rotate(210deg);
         -ms-transform: rotate(210deg);
             transform: rotate(210deg); }
-  .sk-fading-circle .sk-circle9 {
+  .sk.sk-fading-circle .sk-circle9 {
     -webkit-transform: rotate(240deg);
         -ms-transform: rotate(240deg);
             transform: rotate(240deg); }
-  .sk-fading-circle .sk-circle10 {
+  .sk.sk-fading-circle .sk-circle10 {
     -webkit-transform: rotate(270deg);
         -ms-transform: rotate(270deg);
             transform: rotate(270deg); }
-  .sk-fading-circle .sk-circle11 {
+  .sk.sk-fading-circle .sk-circle11 {
     -webkit-transform: rotate(300deg);
         -ms-transform: rotate(300deg);
             transform: rotate(300deg); }
-  .sk-fading-circle .sk-circle12 {
+  .sk.sk-fading-circle .sk-circle12 {
     -webkit-transform: rotate(330deg);
         -ms-transform: rotate(330deg);
             transform: rotate(330deg); }
-  .sk-fading-circle .sk-circle2:before {
+  .sk.sk-fading-circle .sk-circle2:before {
     -webkit-animation-delay: -1.1s;
             animation-delay: -1.1s; }
-  .sk-fading-circle .sk-circle3:before {
+  .sk.sk-fading-circle .sk-circle3:before {
     -webkit-animation-delay: -1s;
             animation-delay: -1s; }
-  .sk-fading-circle .sk-circle4:before {
+  .sk.sk-fading-circle .sk-circle4:before {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
-  .sk-fading-circle .sk-circle5:before {
+  .sk.sk-fading-circle .sk-circle5:before {
     -webkit-animation-delay: -0.8s;
             animation-delay: -0.8s; }
-  .sk-fading-circle .sk-circle6:before {
+  .sk.sk-fading-circle .sk-circle6:before {
     -webkit-animation-delay: -0.7s;
             animation-delay: -0.7s; }
-  .sk-fading-circle .sk-circle7:before {
+  .sk.sk-fading-circle .sk-circle7:before {
     -webkit-animation-delay: -0.6s;
             animation-delay: -0.6s; }
-  .sk-fading-circle .sk-circle8:before {
+  .sk.sk-fading-circle .sk-circle8:before {
     -webkit-animation-delay: -0.5s;
             animation-delay: -0.5s; }
-  .sk-fading-circle .sk-circle9:before {
+  .sk.sk-fading-circle .sk-circle9:before {
     -webkit-animation-delay: -0.4s;
             animation-delay: -0.4s; }
-  .sk-fading-circle .sk-circle10:before {
+  .sk.sk-fading-circle .sk-circle10:before {
     -webkit-animation-delay: -0.3s;
             animation-delay: -0.3s; }
-  .sk-fading-circle .sk-circle11:before {
+  .sk.sk-fading-circle .sk-circle11:before {
     -webkit-animation-delay: -0.2s;
             animation-delay: -0.2s; }
-  .sk-fading-circle .sk-circle12:before {
+  .sk.sk-fading-circle .sk-circle12:before {
     -webkit-animation-delay: -0.1s;
             animation-delay: -0.1s; }
 
@@ -686,7 +1583,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-folding-cube">
+      <div class="sk sk-folding-cube">
         <div class="sk-cube1 sk-cube"></div>
         <div class="sk-cube2 sk-cube"></div>
         <div class="sk-cube4 sk-cube"></div>
@@ -694,14 +1591,97 @@
       </div>
  *
  */
-.sk-folding-cube {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-folding-cube {
   position: relative;
   -webkit-transform: rotateZ(45deg);
           transform: rotateZ(45deg); }
-  .sk-folding-cube .sk-cube {
+  .sk.sk-folding-cube .sk-cube {
     float: left;
     width: 50%;
     height: 50%;
@@ -709,7 +1689,7 @@
     -webkit-transform: scale(1.1);
         -ms-transform: scale(1.1);
             transform: scale(1.1); }
-  .sk-folding-cube .sk-cube:before {
+  .sk.sk-folding-cube .sk-cube:before {
     content: '';
     position: absolute;
     top: 0;
@@ -722,22 +1702,22 @@
     -webkit-transform-origin: 100% 100%;
         -ms-transform-origin: 100% 100%;
             transform-origin: 100% 100%; }
-  .sk-folding-cube .sk-cube2 {
+  .sk.sk-folding-cube .sk-cube2 {
     -webkit-transform: scale(1.1) rotateZ(90deg);
             transform: scale(1.1) rotateZ(90deg); }
-  .sk-folding-cube .sk-cube3 {
+  .sk.sk-folding-cube .sk-cube3 {
     -webkit-transform: scale(1.1) rotateZ(180deg);
             transform: scale(1.1) rotateZ(180deg); }
-  .sk-folding-cube .sk-cube4 {
+  .sk.sk-folding-cube .sk-cube4 {
     -webkit-transform: scale(1.1) rotateZ(270deg);
             transform: scale(1.1) rotateZ(270deg); }
-  .sk-folding-cube .sk-cube2:before {
+  .sk.sk-folding-cube .sk-cube2:before {
     -webkit-animation-delay: 0.3s;
             animation-delay: 0.3s; }
-  .sk-folding-cube .sk-cube3:before {
+  .sk.sk-folding-cube .sk-cube3:before {
     -webkit-animation-delay: 0.6s;
             animation-delay: 0.6s; }
-  .sk-folding-cube .sk-cube4:before {
+  .sk.sk-folding-cube .sk-cube4:before {
     -webkit-animation-delay: 0.9s;
             animation-delay: 0.9s; }
 

--- a/css/spinners/1-rotating-plane.css
+++ b/css/spinners/1-rotating-plane.css
@@ -1,14 +1,97 @@
 /*
  *  Usage:
  *
-      <div class="sk-rotating-plane"></div>
+      <div class="sk sk-rotating-plane"></div>
  *
  */
-.sk-rotating-plane {
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-rotating-plane {
   background-color: #333;
-  margin: 40px auto;
   -webkit-animation: sk-rotatePlane 1.2s infinite ease-in-out;
           animation: sk-rotatePlane 1.2s infinite ease-in-out; }
 

--- a/css/spinners/10-fading-circle.css
+++ b/css/spinners/10-fading-circle.css
@@ -1,7 +1,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-fading-circle">
+      <div class="sk sk-fading-circle">
         <div class="sk-circle1 sk-circle"></div>
         <div class="sk-circle2 sk-circle"></div>
         <div class="sk-circle3 sk-circle"></div>
@@ -17,18 +17,101 @@
       </div>
  *
  */
-.sk-fading-circle {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-fading-circle {
   position: relative; }
-  .sk-fading-circle .sk-circle {
+  .sk.sk-fading-circle .sk-circle {
     width: 100%;
     height: 100%;
     position: absolute;
     left: 0;
     top: 0; }
-  .sk-fading-circle .sk-circle:before {
+  .sk.sk-fading-circle .sk-circle:before {
     content: '';
     display: block;
     margin: 0 auto;
@@ -38,81 +121,81 @@
     border-radius: 100%;
     -webkit-animation: sk-circleFadeDelay 1.2s infinite ease-in-out both;
             animation: sk-circleFadeDelay 1.2s infinite ease-in-out both; }
-  .sk-fading-circle .sk-circle2 {
+  .sk.sk-fading-circle .sk-circle2 {
     -webkit-transform: rotate(30deg);
         -ms-transform: rotate(30deg);
             transform: rotate(30deg); }
-  .sk-fading-circle .sk-circle3 {
+  .sk.sk-fading-circle .sk-circle3 {
     -webkit-transform: rotate(60deg);
         -ms-transform: rotate(60deg);
             transform: rotate(60deg); }
-  .sk-fading-circle .sk-circle4 {
+  .sk.sk-fading-circle .sk-circle4 {
     -webkit-transform: rotate(90deg);
         -ms-transform: rotate(90deg);
             transform: rotate(90deg); }
-  .sk-fading-circle .sk-circle5 {
+  .sk.sk-fading-circle .sk-circle5 {
     -webkit-transform: rotate(120deg);
         -ms-transform: rotate(120deg);
             transform: rotate(120deg); }
-  .sk-fading-circle .sk-circle6 {
+  .sk.sk-fading-circle .sk-circle6 {
     -webkit-transform: rotate(150deg);
         -ms-transform: rotate(150deg);
             transform: rotate(150deg); }
-  .sk-fading-circle .sk-circle7 {
+  .sk.sk-fading-circle .sk-circle7 {
     -webkit-transform: rotate(180deg);
         -ms-transform: rotate(180deg);
             transform: rotate(180deg); }
-  .sk-fading-circle .sk-circle8 {
+  .sk.sk-fading-circle .sk-circle8 {
     -webkit-transform: rotate(210deg);
         -ms-transform: rotate(210deg);
             transform: rotate(210deg); }
-  .sk-fading-circle .sk-circle9 {
+  .sk.sk-fading-circle .sk-circle9 {
     -webkit-transform: rotate(240deg);
         -ms-transform: rotate(240deg);
             transform: rotate(240deg); }
-  .sk-fading-circle .sk-circle10 {
+  .sk.sk-fading-circle .sk-circle10 {
     -webkit-transform: rotate(270deg);
         -ms-transform: rotate(270deg);
             transform: rotate(270deg); }
-  .sk-fading-circle .sk-circle11 {
+  .sk.sk-fading-circle .sk-circle11 {
     -webkit-transform: rotate(300deg);
         -ms-transform: rotate(300deg);
             transform: rotate(300deg); }
-  .sk-fading-circle .sk-circle12 {
+  .sk.sk-fading-circle .sk-circle12 {
     -webkit-transform: rotate(330deg);
         -ms-transform: rotate(330deg);
             transform: rotate(330deg); }
-  .sk-fading-circle .sk-circle2:before {
+  .sk.sk-fading-circle .sk-circle2:before {
     -webkit-animation-delay: -1.1s;
             animation-delay: -1.1s; }
-  .sk-fading-circle .sk-circle3:before {
+  .sk.sk-fading-circle .sk-circle3:before {
     -webkit-animation-delay: -1s;
             animation-delay: -1s; }
-  .sk-fading-circle .sk-circle4:before {
+  .sk.sk-fading-circle .sk-circle4:before {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
-  .sk-fading-circle .sk-circle5:before {
+  .sk.sk-fading-circle .sk-circle5:before {
     -webkit-animation-delay: -0.8s;
             animation-delay: -0.8s; }
-  .sk-fading-circle .sk-circle6:before {
+  .sk.sk-fading-circle .sk-circle6:before {
     -webkit-animation-delay: -0.7s;
             animation-delay: -0.7s; }
-  .sk-fading-circle .sk-circle7:before {
+  .sk.sk-fading-circle .sk-circle7:before {
     -webkit-animation-delay: -0.6s;
             animation-delay: -0.6s; }
-  .sk-fading-circle .sk-circle8:before {
+  .sk.sk-fading-circle .sk-circle8:before {
     -webkit-animation-delay: -0.5s;
             animation-delay: -0.5s; }
-  .sk-fading-circle .sk-circle9:before {
+  .sk.sk-fading-circle .sk-circle9:before {
     -webkit-animation-delay: -0.4s;
             animation-delay: -0.4s; }
-  .sk-fading-circle .sk-circle10:before {
+  .sk.sk-fading-circle .sk-circle10:before {
     -webkit-animation-delay: -0.3s;
             animation-delay: -0.3s; }
-  .sk-fading-circle .sk-circle11:before {
+  .sk.sk-fading-circle .sk-circle11:before {
     -webkit-animation-delay: -0.2s;
             animation-delay: -0.2s; }
-  .sk-fading-circle .sk-circle12:before {
+  .sk.sk-fading-circle .sk-circle12:before {
     -webkit-animation-delay: -0.1s;
             animation-delay: -0.1s; }
 

--- a/css/spinners/11-folding-cube.css
+++ b/css/spinners/11-folding-cube.css
@@ -1,7 +1,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-folding-cube">
+      <div class="sk sk-folding-cube">
         <div class="sk-cube1 sk-cube"></div>
         <div class="sk-cube2 sk-cube"></div>
         <div class="sk-cube4 sk-cube"></div>
@@ -9,14 +9,97 @@
       </div>
  *
  */
-.sk-folding-cube {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-folding-cube {
   position: relative;
   -webkit-transform: rotateZ(45deg);
           transform: rotateZ(45deg); }
-  .sk-folding-cube .sk-cube {
+  .sk.sk-folding-cube .sk-cube {
     float: left;
     width: 50%;
     height: 50%;
@@ -24,7 +107,7 @@
     -webkit-transform: scale(1.1);
         -ms-transform: scale(1.1);
             transform: scale(1.1); }
-  .sk-folding-cube .sk-cube:before {
+  .sk.sk-folding-cube .sk-cube:before {
     content: '';
     position: absolute;
     top: 0;
@@ -37,22 +120,22 @@
     -webkit-transform-origin: 100% 100%;
         -ms-transform-origin: 100% 100%;
             transform-origin: 100% 100%; }
-  .sk-folding-cube .sk-cube2 {
+  .sk.sk-folding-cube .sk-cube2 {
     -webkit-transform: scale(1.1) rotateZ(90deg);
             transform: scale(1.1) rotateZ(90deg); }
-  .sk-folding-cube .sk-cube3 {
+  .sk.sk-folding-cube .sk-cube3 {
     -webkit-transform: scale(1.1) rotateZ(180deg);
             transform: scale(1.1) rotateZ(180deg); }
-  .sk-folding-cube .sk-cube4 {
+  .sk.sk-folding-cube .sk-cube4 {
     -webkit-transform: scale(1.1) rotateZ(270deg);
             transform: scale(1.1) rotateZ(270deg); }
-  .sk-folding-cube .sk-cube2:before {
+  .sk.sk-folding-cube .sk-cube2:before {
     -webkit-animation-delay: 0.3s;
             animation-delay: 0.3s; }
-  .sk-folding-cube .sk-cube3:before {
+  .sk.sk-folding-cube .sk-cube3:before {
     -webkit-animation-delay: 0.6s;
             animation-delay: 0.6s; }
-  .sk-folding-cube .sk-cube4:before {
+  .sk.sk-folding-cube .sk-cube4:before {
     -webkit-animation-delay: 0.9s;
             animation-delay: 0.9s; }
 

--- a/css/spinners/2-double-bounce.css
+++ b/css/spinners/2-double-bounce.css
@@ -1,18 +1,101 @@
 /*
  *  Usage:
  *
-      <div class="sk-double-bounce">
+      <div class="sk sk-double-bounce">
         <div class="sk-child sk-double-bounce1"></div>
         <div class="sk-child sk-double-bounce2"></div>
       </div>
  *
  */
-.sk-double-bounce {
-  width: 40px;
-  height: 40px;
-  position: relative;
-  margin: 40px auto; }
-  .sk-double-bounce .sk-child {
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-double-bounce {
+  position: relative; }
+  .sk.sk-double-bounce .sk-child {
     width: 100%;
     height: 100%;
     border-radius: 50%;
@@ -21,9 +104,9 @@
     position: absolute;
     top: 0;
     left: 0;
-    -webkit-animation: sk-doubleBounce 2s infinite ease-in-out;
-            animation: sk-doubleBounce 2s infinite ease-in-out; }
-  .sk-double-bounce .sk-double-bounce2 {
+    -webkit-animation: sk-doubleBounce 2.0s infinite ease-in-out;
+            animation: sk-doubleBounce 2.0s infinite ease-in-out; }
+  .sk.sk-double-bounce .sk-double-bounce2 {
     -webkit-animation-delay: -1.0s;
             animation-delay: -1.0s; }
 

--- a/css/spinners/3-wave.css
+++ b/css/spinners/3-wave.css
@@ -1,7 +1,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-wave">
+      <div class="sk sk-wave">
         <div class="sk-rect sk-rect1"></div>
         <div class="sk-rect sk-rect2"></div>
         <div class="sk-rect sk-rect3"></div>
@@ -10,32 +10,140 @@
       </div>
  *
  */
-.sk-wave {
-  margin: 40px auto;
-  width: 50px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-wave {
   text-align: center;
   font-size: 10px; }
-  .sk-wave .sk-rect {
+  .sk.sk-wave .sk-rect {
     background-color: #333;
     height: 100%;
     width: 6px;
     display: inline-block;
     -webkit-animation: sk-waveStretchDelay 1.2s infinite ease-in-out;
             animation: sk-waveStretchDelay 1.2s infinite ease-in-out; }
-  .sk-wave .sk-rect1 {
+  .sk.sk-wave.sk-xs-width, .sk.sk-wave.sk-xs {
+    width: 12.5px;
+    font-size: 2.5px; }
+    .sk.sk-wave.sk-xs-width .sk-rect, .sk.sk-wave.sk-xs .sk-rect {
+      width: 1.5px; }
+  .sk.sk-wave.sk-sm-width, .sk.sk-wave.sk-sm {
+    width: 25px;
+    font-size: 5px; }
+    .sk.sk-wave.sk-sm-width .sk-rect, .sk.sk-wave.sk-sm .sk-rect {
+      width: 3px; }
+  .sk.sk-wave.sk-md-width, .sk.sk-wave.sk-md {
+    width: 50px;
+    font-size: 10px; }
+    .sk.sk-wave.sk-md-width .sk-rect, .sk.sk-wave.sk-md .sk-rect {
+      width: 6px; }
+  .sk.sk-wave.sk-lg-width, .sk.sk-wave.sk-lg {
+    width: 75px;
+    font-size: 15px; }
+    .sk.sk-wave.sk-lg-width .sk-rect, .sk.sk-wave.sk-lg .sk-rect {
+      width: 9px; }
+  .sk.sk-wave.sk-xl-width, .sk.sk-wave.sk-xl {
+    width: 125px;
+    font-size: 25px; }
+    .sk.sk-wave.sk-xl-width .sk-rect, .sk.sk-wave.sk-xl .sk-rect {
+      width: 15px; }
+  .sk.sk-wave .sk-rect1 {
     -webkit-animation-delay: -1.2s;
             animation-delay: -1.2s; }
-  .sk-wave .sk-rect2 {
+  .sk.sk-wave .sk-rect2 {
     -webkit-animation-delay: -1.1s;
             animation-delay: -1.1s; }
-  .sk-wave .sk-rect3 {
+  .sk.sk-wave .sk-rect3 {
     -webkit-animation-delay: -1s;
             animation-delay: -1s; }
-  .sk-wave .sk-rect4 {
+  .sk.sk-wave .sk-rect4 {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
-  .sk-wave .sk-rect5 {
+  .sk.sk-wave .sk-rect5 {
     -webkit-animation-delay: -0.8s;
             animation-delay: -0.8s; }
 

--- a/css/spinners/4-wandering-cubes.css
+++ b/css/spinners/4-wandering-cubes.css
@@ -1,18 +1,101 @@
 /*
  *  Usage:
  *
-      <div class="sk-wandering-cubes">
+      <div class="sk sk-wandering-cubes">
         <div class="sk-cube sk-cube1"></div>
         <div class="sk-cube sk-cube2"></div>
       </div>
  *
  */
-.sk-wandering-cubes {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-wandering-cubes {
   position: relative; }
-  .sk-wandering-cubes .sk-cube {
+  .sk.sk-wandering-cubes .sk-cube {
     background-color: #333;
     width: 10px;
     height: 10px;
@@ -21,9 +104,24 @@
     left: 0;
     -webkit-animation: sk-wanderingCube 1.8s ease-in-out -1.8s infinite both;
             animation: sk-wanderingCube 1.8s ease-in-out -1.8s infinite both; }
-  .sk-wandering-cubes .sk-cube2 {
+  .sk.sk-wandering-cubes .sk-cube2 {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
+  .sk.sk-wandering-cubes.sk-xs-width, .sk.sk-wandering-cubes.sk-xs {
+    width: 2.5px;
+    height: 2.5px; }
+  .sk.sk-wandering-cubes.sk-sm-width, .sk.sk-wandering-cubes.sk-sm {
+    width: 5px;
+    height: 5px; }
+  .sk.sk-wandering-cubes.sk-md-width, .sk.sk-wandering-cubes.sk-md {
+    width: 10px;
+    height: 10px; }
+  .sk.sk-wandering-cubes.sk-lg-width, .sk.sk-wandering-cubes.sk-lg {
+    width: 15px;
+    height: 15px; }
+  .sk.sk-wandering-cubes.sk-xl-width, .sk.sk-wandering-cubes.sk-xl {
+    width: 25px;
+    height: 25px; }
 
 @-webkit-keyframes sk-wanderingCube {
   0% {

--- a/css/spinners/5-pulse.css
+++ b/css/spinners/5-pulse.css
@@ -1,17 +1,100 @@
 /*
  *  Usage:
  *
-      <div class="sk-spinner sk-spinner-pulse"></div>
+      <div class="sk sk-pulse"></div>
  *
  */
-.sk-spinner-pulse {
-  width: 40px;
-  height: 40px;
-  margin: 40px auto;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-pulse {
   background-color: #333;
   border-radius: 100%;
-  -webkit-animation: sk-pulseScaleOut 1s infinite ease-in-out;
-          animation: sk-pulseScaleOut 1s infinite ease-in-out; }
+  -webkit-animation: sk-pulseScaleOut 1.0s infinite ease-in-out;
+          animation: sk-pulseScaleOut 1.0s infinite ease-in-out; }
 
 @-webkit-keyframes sk-pulseScaleOut {
   0% {

--- a/css/spinners/6-chasing-dots.css
+++ b/css/spinners/6-chasing-dots.css
@@ -1,21 +1,104 @@
 /*
  *  Usage:
  *
-      <div class="sk-chasing-dots">
+      <div class="sk sk-chasing-dots">
         <div class="sk-child sk-dot1"></div>
         <div class="sk-child sk-dot2"></div>
       </div>
  *
  */
-.sk-chasing-dots {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-chasing-dots {
   position: relative;
   text-align: center;
   -webkit-animation: sk-chasingDotsRotate 2s infinite linear;
           animation: sk-chasingDotsRotate 2s infinite linear; }
-  .sk-chasing-dots .sk-child {
+  .sk.sk-chasing-dots .sk-child {
     width: 60%;
     height: 60%;
     display: inline-block;
@@ -25,7 +108,7 @@
     border-radius: 100%;
     -webkit-animation: sk-chasingDotsBounce 2s infinite ease-in-out;
             animation: sk-chasingDotsBounce 2s infinite ease-in-out; }
-  .sk-chasing-dots .sk-dot2 {
+  .sk.sk-chasing-dots .sk-dot2 {
     top: auto;
     bottom: 0;
     -webkit-animation-delay: -1s;

--- a/css/spinners/7-three-bounce.css
+++ b/css/spinners/7-three-bounce.css
@@ -1,18 +1,103 @@
 /*
  *  Usage:
  *
-      <div class="sk-three-bounce">
+      <div class="sk sk-three-bounce">
         <div class="sk-child sk-bounce1"></div>
         <div class="sk-child sk-bounce2"></div>
         <div class="sk-child sk-bounce3"></div>
       </div>
  *
  */
-.sk-three-bounce {
-  margin: 40px auto;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-three-bounce {
   width: 80px;
   text-align: center; }
-  .sk-three-bounce .sk-child {
+  .sk.sk-three-bounce .sk-child {
     width: 20px;
     height: 20px;
     background-color: #333;
@@ -20,10 +105,35 @@
     display: inline-block;
     -webkit-animation: sk-three-bounce 1.4s ease-in-out 0s infinite both;
             animation: sk-three-bounce 1.4s ease-in-out 0s infinite both; }
-  .sk-three-bounce .sk-bounce1 {
+  .sk.sk-three-bounce.sk-xs-width, .sk.sk-three-bounce.sk-xs {
+    width: 25px; }
+    .sk.sk-three-bounce.sk-xs-width .sk-child, .sk.sk-three-bounce.sk-xs .sk-child {
+      width: 4px;
+      height: 4px; }
+  .sk.sk-three-bounce.sk-sm-width, .sk.sk-three-bounce.sk-sm {
+    width: 40px; }
+    .sk.sk-three-bounce.sk-sm-width .sk-child, .sk.sk-three-bounce.sk-sm .sk-child {
+      width: 10px;
+      height: 10px; }
+  .sk.sk-three-bounce.sk-md-width, .sk.sk-three-bounce.sk-md {
+    width: 80px; }
+    .sk.sk-three-bounce.sk-md-width .sk-child, .sk.sk-three-bounce.sk-md .sk-child {
+      width: 20px;
+      height: 20px; }
+  .sk.sk-three-bounce.sk-lg-width, .sk.sk-three-bounce.sk-lg {
+    width: 120px; }
+    .sk.sk-three-bounce.sk-lg-width .sk-child, .sk.sk-three-bounce.sk-lg .sk-child {
+      width: 30px;
+      height: 30px; }
+  .sk.sk-three-bounce.sk-xl-width, .sk.sk-three-bounce.sk-xl {
+    width: 200px; }
+    .sk.sk-three-bounce.sk-xl-width .sk-child, .sk.sk-three-bounce.sk-xl .sk-child {
+      width: 50px;
+      height: 50px; }
+  .sk.sk-three-bounce .sk-bounce1 {
     -webkit-animation-delay: -0.32s;
             animation-delay: -0.32s; }
-  .sk-three-bounce .sk-bounce2 {
+  .sk.sk-three-bounce .sk-bounce2 {
     -webkit-animation-delay: -0.16s;
             animation-delay: -0.16s; }
 

--- a/css/spinners/8-circle.css
+++ b/css/spinners/8-circle.css
@@ -1,7 +1,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-circle">
+      <div class="sk sk-circle">
         <div class="sk-circle1 sk-child"></div>
         <div class="sk-circle2 sk-child"></div>
         <div class="sk-circle3 sk-child"></div>
@@ -17,18 +17,101 @@
       </div>
  *
  */
-.sk-circle {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-circle {
   position: relative; }
-  .sk-circle .sk-child {
+  .sk.sk-circle .sk-child {
     width: 100%;
     height: 100%;
     position: absolute;
     left: 0;
     top: 0; }
-  .sk-circle .sk-child:before {
+  .sk.sk-circle .sk-child:before {
     content: '';
     display: block;
     margin: 0 auto;
@@ -38,81 +121,81 @@
     border-radius: 100%;
     -webkit-animation: sk-circleBounceDelay 1.2s infinite ease-in-out both;
             animation: sk-circleBounceDelay 1.2s infinite ease-in-out both; }
-  .sk-circle .sk-circle2 {
+  .sk.sk-circle .sk-circle2 {
     -webkit-transform: rotate(30deg);
         -ms-transform: rotate(30deg);
             transform: rotate(30deg); }
-  .sk-circle .sk-circle3 {
+  .sk.sk-circle .sk-circle3 {
     -webkit-transform: rotate(60deg);
         -ms-transform: rotate(60deg);
             transform: rotate(60deg); }
-  .sk-circle .sk-circle4 {
+  .sk.sk-circle .sk-circle4 {
     -webkit-transform: rotate(90deg);
         -ms-transform: rotate(90deg);
             transform: rotate(90deg); }
-  .sk-circle .sk-circle5 {
+  .sk.sk-circle .sk-circle5 {
     -webkit-transform: rotate(120deg);
         -ms-transform: rotate(120deg);
             transform: rotate(120deg); }
-  .sk-circle .sk-circle6 {
+  .sk.sk-circle .sk-circle6 {
     -webkit-transform: rotate(150deg);
         -ms-transform: rotate(150deg);
             transform: rotate(150deg); }
-  .sk-circle .sk-circle7 {
+  .sk.sk-circle .sk-circle7 {
     -webkit-transform: rotate(180deg);
         -ms-transform: rotate(180deg);
             transform: rotate(180deg); }
-  .sk-circle .sk-circle8 {
+  .sk.sk-circle .sk-circle8 {
     -webkit-transform: rotate(210deg);
         -ms-transform: rotate(210deg);
             transform: rotate(210deg); }
-  .sk-circle .sk-circle9 {
+  .sk.sk-circle .sk-circle9 {
     -webkit-transform: rotate(240deg);
         -ms-transform: rotate(240deg);
             transform: rotate(240deg); }
-  .sk-circle .sk-circle10 {
+  .sk.sk-circle .sk-circle10 {
     -webkit-transform: rotate(270deg);
         -ms-transform: rotate(270deg);
             transform: rotate(270deg); }
-  .sk-circle .sk-circle11 {
+  .sk.sk-circle .sk-circle11 {
     -webkit-transform: rotate(300deg);
         -ms-transform: rotate(300deg);
             transform: rotate(300deg); }
-  .sk-circle .sk-circle12 {
+  .sk.sk-circle .sk-circle12 {
     -webkit-transform: rotate(330deg);
         -ms-transform: rotate(330deg);
             transform: rotate(330deg); }
-  .sk-circle .sk-circle2:before {
+  .sk.sk-circle .sk-circle2:before {
     -webkit-animation-delay: -1.1s;
             animation-delay: -1.1s; }
-  .sk-circle .sk-circle3:before {
+  .sk.sk-circle .sk-circle3:before {
     -webkit-animation-delay: -1s;
             animation-delay: -1s; }
-  .sk-circle .sk-circle4:before {
+  .sk.sk-circle .sk-circle4:before {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
-  .sk-circle .sk-circle5:before {
+  .sk.sk-circle .sk-circle5:before {
     -webkit-animation-delay: -0.8s;
             animation-delay: -0.8s; }
-  .sk-circle .sk-circle6:before {
+  .sk.sk-circle .sk-circle6:before {
     -webkit-animation-delay: -0.7s;
             animation-delay: -0.7s; }
-  .sk-circle .sk-circle7:before {
+  .sk.sk-circle .sk-circle7:before {
     -webkit-animation-delay: -0.6s;
             animation-delay: -0.6s; }
-  .sk-circle .sk-circle8:before {
+  .sk.sk-circle .sk-circle8:before {
     -webkit-animation-delay: -0.5s;
             animation-delay: -0.5s; }
-  .sk-circle .sk-circle9:before {
+  .sk.sk-circle .sk-circle9:before {
     -webkit-animation-delay: -0.4s;
             animation-delay: -0.4s; }
-  .sk-circle .sk-circle10:before {
+  .sk.sk-circle .sk-circle10:before {
     -webkit-animation-delay: -0.3s;
             animation-delay: -0.3s; }
-  .sk-circle .sk-circle11:before {
+  .sk.sk-circle .sk-circle11:before {
     -webkit-animation-delay: -0.2s;
             animation-delay: -0.2s; }
-  .sk-circle .sk-circle12:before {
+  .sk.sk-circle .sk-circle12:before {
     -webkit-animation-delay: -0.1s;
             animation-delay: -0.1s; }
 

--- a/css/spinners/9-cube-grid.css
+++ b/css/spinners/9-cube-grid.css
@@ -1,7 +1,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-cube-grid">
+      <div class="sk sk-cube-grid">
         <div class="sk-cube sk-cube1"></div>
         <div class="sk-cube sk-cube2"></div>
         <div class="sk-cube sk-cube3"></div>
@@ -14,48 +14,131 @@
       </div>
  *
  */
-.sk-cube-grid {
-  width: 40px;
-  height: 40px;
-  margin: 40px auto;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-cube-grid {
   /*
    * Spinner positions
    * 1 2 3
    * 4 5 6
    * 7 8 9
    */ }
-  .sk-cube-grid .sk-cube {
+  .sk.sk-cube-grid .sk-cube {
     width: 33.33%;
     height: 33.33%;
     background-color: #333;
     float: left;
     -webkit-animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
             animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out; }
-  .sk-cube-grid .sk-cube1 {
+  .sk.sk-cube-grid .sk-cube1 {
     -webkit-animation-delay: 0.2s;
             animation-delay: 0.2s; }
-  .sk-cube-grid .sk-cube2 {
+  .sk.sk-cube-grid .sk-cube2 {
     -webkit-animation-delay: 0.3s;
             animation-delay: 0.3s; }
-  .sk-cube-grid .sk-cube3 {
+  .sk.sk-cube-grid .sk-cube3 {
     -webkit-animation-delay: 0.4s;
             animation-delay: 0.4s; }
-  .sk-cube-grid .sk-cube4 {
+  .sk.sk-cube-grid .sk-cube4 {
     -webkit-animation-delay: 0.1s;
             animation-delay: 0.1s; }
-  .sk-cube-grid .sk-cube5 {
+  .sk.sk-cube-grid .sk-cube5 {
     -webkit-animation-delay: 0.2s;
             animation-delay: 0.2s; }
-  .sk-cube-grid .sk-cube6 {
+  .sk.sk-cube-grid .sk-cube6 {
     -webkit-animation-delay: 0.3s;
             animation-delay: 0.3s; }
-  .sk-cube-grid .sk-cube7 {
+  .sk.sk-cube-grid .sk-cube7 {
     -webkit-animation-delay: 0.0s;
             animation-delay: 0.0s; }
-  .sk-cube-grid .sk-cube8 {
+  .sk.sk-cube-grid .sk-cube8 {
     -webkit-animation-delay: 0.1s;
             animation-delay: 0.1s; }
-  .sk-cube-grid .sk-cube9 {
+  .sk.sk-cube-grid .sk-cube9 {
     -webkit-animation-delay: 0.2s;
             animation-delay: 0.2s; }
 

--- a/examples/1-rotating-plane.html
+++ b/examples/1-rotating-plane.html
@@ -6,14 +6,97 @@
     /*
  *  Usage:
  *
-      <div class="sk-rotating-plane"></div>
+      <div class="sk sk-rotating-plane"></div>
  *
  */
-.sk-rotating-plane {
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-rotating-plane {
   background-color: #333;
-  margin: 40px auto;
   -webkit-animation: sk-rotatePlane 1.2s infinite ease-in-out;
           animation: sk-rotatePlane 1.2s infinite ease-in-out; }
 
@@ -44,6 +127,6 @@
 <body>
  
 
-      <div class="sk-rotating-plane"></div>
+      <div class="sk sk-rotating-plane"></div>
 </body>
 </html>

--- a/examples/10-fading-circle.html
+++ b/examples/10-fading-circle.html
@@ -6,7 +6,7 @@
     /*
  *  Usage:
  *
-      <div class="sk-fading-circle">
+      <div class="sk sk-fading-circle">
         <div class="sk-circle1 sk-circle"></div>
         <div class="sk-circle2 sk-circle"></div>
         <div class="sk-circle3 sk-circle"></div>
@@ -22,18 +22,101 @@
       </div>
  *
  */
-.sk-fading-circle {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-fading-circle {
   position: relative; }
-  .sk-fading-circle .sk-circle {
+  .sk.sk-fading-circle .sk-circle {
     width: 100%;
     height: 100%;
     position: absolute;
     left: 0;
     top: 0; }
-  .sk-fading-circle .sk-circle:before {
+  .sk.sk-fading-circle .sk-circle:before {
     content: '';
     display: block;
     margin: 0 auto;
@@ -43,81 +126,81 @@
     border-radius: 100%;
     -webkit-animation: sk-circleFadeDelay 1.2s infinite ease-in-out both;
             animation: sk-circleFadeDelay 1.2s infinite ease-in-out both; }
-  .sk-fading-circle .sk-circle2 {
+  .sk.sk-fading-circle .sk-circle2 {
     -webkit-transform: rotate(30deg);
         -ms-transform: rotate(30deg);
             transform: rotate(30deg); }
-  .sk-fading-circle .sk-circle3 {
+  .sk.sk-fading-circle .sk-circle3 {
     -webkit-transform: rotate(60deg);
         -ms-transform: rotate(60deg);
             transform: rotate(60deg); }
-  .sk-fading-circle .sk-circle4 {
+  .sk.sk-fading-circle .sk-circle4 {
     -webkit-transform: rotate(90deg);
         -ms-transform: rotate(90deg);
             transform: rotate(90deg); }
-  .sk-fading-circle .sk-circle5 {
+  .sk.sk-fading-circle .sk-circle5 {
     -webkit-transform: rotate(120deg);
         -ms-transform: rotate(120deg);
             transform: rotate(120deg); }
-  .sk-fading-circle .sk-circle6 {
+  .sk.sk-fading-circle .sk-circle6 {
     -webkit-transform: rotate(150deg);
         -ms-transform: rotate(150deg);
             transform: rotate(150deg); }
-  .sk-fading-circle .sk-circle7 {
+  .sk.sk-fading-circle .sk-circle7 {
     -webkit-transform: rotate(180deg);
         -ms-transform: rotate(180deg);
             transform: rotate(180deg); }
-  .sk-fading-circle .sk-circle8 {
+  .sk.sk-fading-circle .sk-circle8 {
     -webkit-transform: rotate(210deg);
         -ms-transform: rotate(210deg);
             transform: rotate(210deg); }
-  .sk-fading-circle .sk-circle9 {
+  .sk.sk-fading-circle .sk-circle9 {
     -webkit-transform: rotate(240deg);
         -ms-transform: rotate(240deg);
             transform: rotate(240deg); }
-  .sk-fading-circle .sk-circle10 {
+  .sk.sk-fading-circle .sk-circle10 {
     -webkit-transform: rotate(270deg);
         -ms-transform: rotate(270deg);
             transform: rotate(270deg); }
-  .sk-fading-circle .sk-circle11 {
+  .sk.sk-fading-circle .sk-circle11 {
     -webkit-transform: rotate(300deg);
         -ms-transform: rotate(300deg);
             transform: rotate(300deg); }
-  .sk-fading-circle .sk-circle12 {
+  .sk.sk-fading-circle .sk-circle12 {
     -webkit-transform: rotate(330deg);
         -ms-transform: rotate(330deg);
             transform: rotate(330deg); }
-  .sk-fading-circle .sk-circle2:before {
+  .sk.sk-fading-circle .sk-circle2:before {
     -webkit-animation-delay: -1.1s;
             animation-delay: -1.1s; }
-  .sk-fading-circle .sk-circle3:before {
+  .sk.sk-fading-circle .sk-circle3:before {
     -webkit-animation-delay: -1s;
             animation-delay: -1s; }
-  .sk-fading-circle .sk-circle4:before {
+  .sk.sk-fading-circle .sk-circle4:before {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
-  .sk-fading-circle .sk-circle5:before {
+  .sk.sk-fading-circle .sk-circle5:before {
     -webkit-animation-delay: -0.8s;
             animation-delay: -0.8s; }
-  .sk-fading-circle .sk-circle6:before {
+  .sk.sk-fading-circle .sk-circle6:before {
     -webkit-animation-delay: -0.7s;
             animation-delay: -0.7s; }
-  .sk-fading-circle .sk-circle7:before {
+  .sk.sk-fading-circle .sk-circle7:before {
     -webkit-animation-delay: -0.6s;
             animation-delay: -0.6s; }
-  .sk-fading-circle .sk-circle8:before {
+  .sk.sk-fading-circle .sk-circle8:before {
     -webkit-animation-delay: -0.5s;
             animation-delay: -0.5s; }
-  .sk-fading-circle .sk-circle9:before {
+  .sk.sk-fading-circle .sk-circle9:before {
     -webkit-animation-delay: -0.4s;
             animation-delay: -0.4s; }
-  .sk-fading-circle .sk-circle10:before {
+  .sk.sk-fading-circle .sk-circle10:before {
     -webkit-animation-delay: -0.3s;
             animation-delay: -0.3s; }
-  .sk-fading-circle .sk-circle11:before {
+  .sk.sk-fading-circle .sk-circle11:before {
     -webkit-animation-delay: -0.2s;
             animation-delay: -0.2s; }
-  .sk-fading-circle .sk-circle12:before {
+  .sk.sk-fading-circle .sk-circle12:before {
     -webkit-animation-delay: -0.1s;
             animation-delay: -0.1s; }
 
@@ -138,7 +221,7 @@
 <body>
  
 
-      <div class="sk-fading-circle">
+      <div class="sk sk-fading-circle">
         <div class="sk-circle1 sk-circle"></div>
         <div class="sk-circle2 sk-circle"></div>
         <div class="sk-circle3 sk-circle"></div>

--- a/examples/11-folding-cube.html
+++ b/examples/11-folding-cube.html
@@ -6,7 +6,7 @@
     /*
  *  Usage:
  *
-      <div class="sk-folding-cube">
+      <div class="sk sk-folding-cube">
         <div class="sk-cube1 sk-cube"></div>
         <div class="sk-cube2 sk-cube"></div>
         <div class="sk-cube4 sk-cube"></div>
@@ -14,14 +14,97 @@
       </div>
  *
  */
-.sk-folding-cube {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-folding-cube {
   position: relative;
   -webkit-transform: rotateZ(45deg);
           transform: rotateZ(45deg); }
-  .sk-folding-cube .sk-cube {
+  .sk.sk-folding-cube .sk-cube {
     float: left;
     width: 50%;
     height: 50%;
@@ -29,7 +112,7 @@
     -webkit-transform: scale(1.1);
         -ms-transform: scale(1.1);
             transform: scale(1.1); }
-  .sk-folding-cube .sk-cube:before {
+  .sk.sk-folding-cube .sk-cube:before {
     content: '';
     position: absolute;
     top: 0;
@@ -42,22 +125,22 @@
     -webkit-transform-origin: 100% 100%;
         -ms-transform-origin: 100% 100%;
             transform-origin: 100% 100%; }
-  .sk-folding-cube .sk-cube2 {
+  .sk.sk-folding-cube .sk-cube2 {
     -webkit-transform: scale(1.1) rotateZ(90deg);
             transform: scale(1.1) rotateZ(90deg); }
-  .sk-folding-cube .sk-cube3 {
+  .sk.sk-folding-cube .sk-cube3 {
     -webkit-transform: scale(1.1) rotateZ(180deg);
             transform: scale(1.1) rotateZ(180deg); }
-  .sk-folding-cube .sk-cube4 {
+  .sk.sk-folding-cube .sk-cube4 {
     -webkit-transform: scale(1.1) rotateZ(270deg);
             transform: scale(1.1) rotateZ(270deg); }
-  .sk-folding-cube .sk-cube2:before {
+  .sk.sk-folding-cube .sk-cube2:before {
     -webkit-animation-delay: 0.3s;
             animation-delay: 0.3s; }
-  .sk-folding-cube .sk-cube3:before {
+  .sk.sk-folding-cube .sk-cube3:before {
     -webkit-animation-delay: 0.6s;
             animation-delay: 0.6s; }
-  .sk-folding-cube .sk-cube4:before {
+  .sk.sk-folding-cube .sk-cube4:before {
     -webkit-animation-delay: 0.9s;
             animation-delay: 0.9s; }
 
@@ -94,7 +177,7 @@
 <body>
  
 
-      <div class="sk-folding-cube">
+      <div class="sk sk-folding-cube">
         <div class="sk-cube1 sk-cube"></div>
         <div class="sk-cube2 sk-cube"></div>
         <div class="sk-cube4 sk-cube"></div>

--- a/examples/2-double-bounce.html
+++ b/examples/2-double-bounce.html
@@ -6,18 +6,101 @@
     /*
  *  Usage:
  *
-      <div class="sk-double-bounce">
+      <div class="sk sk-double-bounce">
         <div class="sk-child sk-double-bounce1"></div>
         <div class="sk-child sk-double-bounce2"></div>
       </div>
  *
  */
-.sk-double-bounce {
-  width: 40px;
-  height: 40px;
-  position: relative;
-  margin: 40px auto; }
-  .sk-double-bounce .sk-child {
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-double-bounce {
+  position: relative; }
+  .sk.sk-double-bounce .sk-child {
     width: 100%;
     height: 100%;
     border-radius: 50%;
@@ -26,9 +109,9 @@
     position: absolute;
     top: 0;
     left: 0;
-    -webkit-animation: sk-doubleBounce 2s infinite ease-in-out;
-            animation: sk-doubleBounce 2s infinite ease-in-out; }
-  .sk-double-bounce .sk-double-bounce2 {
+    -webkit-animation: sk-doubleBounce 2.0s infinite ease-in-out;
+            animation: sk-doubleBounce 2.0s infinite ease-in-out; }
+  .sk.sk-double-bounce .sk-double-bounce2 {
     -webkit-animation-delay: -1.0s;
             animation-delay: -1.0s; }
 
@@ -53,7 +136,7 @@
 <body>
  
 
-      <div class="sk-double-bounce">
+      <div class="sk sk-double-bounce">
         <div class="sk-child sk-double-bounce1"></div>
         <div class="sk-child sk-double-bounce2"></div>
       </div>

--- a/examples/3-wave.html
+++ b/examples/3-wave.html
@@ -6,7 +6,7 @@
     /*
  *  Usage:
  *
-      <div class="sk-wave">
+      <div class="sk sk-wave">
         <div class="sk-rect sk-rect1"></div>
         <div class="sk-rect sk-rect2"></div>
         <div class="sk-rect sk-rect3"></div>
@@ -15,32 +15,140 @@
       </div>
  *
  */
-.sk-wave {
-  margin: 40px auto;
-  width: 50px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-wave {
   text-align: center;
   font-size: 10px; }
-  .sk-wave .sk-rect {
+  .sk.sk-wave .sk-rect {
     background-color: #333;
     height: 100%;
     width: 6px;
     display: inline-block;
     -webkit-animation: sk-waveStretchDelay 1.2s infinite ease-in-out;
             animation: sk-waveStretchDelay 1.2s infinite ease-in-out; }
-  .sk-wave .sk-rect1 {
+  .sk.sk-wave.sk-xs-width, .sk.sk-wave.sk-xs {
+    width: 12.5px;
+    font-size: 2.5px; }
+    .sk.sk-wave.sk-xs-width .sk-rect, .sk.sk-wave.sk-xs .sk-rect {
+      width: 1.5px; }
+  .sk.sk-wave.sk-sm-width, .sk.sk-wave.sk-sm {
+    width: 25px;
+    font-size: 5px; }
+    .sk.sk-wave.sk-sm-width .sk-rect, .sk.sk-wave.sk-sm .sk-rect {
+      width: 3px; }
+  .sk.sk-wave.sk-md-width, .sk.sk-wave.sk-md {
+    width: 50px;
+    font-size: 10px; }
+    .sk.sk-wave.sk-md-width .sk-rect, .sk.sk-wave.sk-md .sk-rect {
+      width: 6px; }
+  .sk.sk-wave.sk-lg-width, .sk.sk-wave.sk-lg {
+    width: 75px;
+    font-size: 15px; }
+    .sk.sk-wave.sk-lg-width .sk-rect, .sk.sk-wave.sk-lg .sk-rect {
+      width: 9px; }
+  .sk.sk-wave.sk-xl-width, .sk.sk-wave.sk-xl {
+    width: 125px;
+    font-size: 25px; }
+    .sk.sk-wave.sk-xl-width .sk-rect, .sk.sk-wave.sk-xl .sk-rect {
+      width: 15px; }
+  .sk.sk-wave .sk-rect1 {
     -webkit-animation-delay: -1.2s;
             animation-delay: -1.2s; }
-  .sk-wave .sk-rect2 {
+  .sk.sk-wave .sk-rect2 {
     -webkit-animation-delay: -1.1s;
             animation-delay: -1.1s; }
-  .sk-wave .sk-rect3 {
+  .sk.sk-wave .sk-rect3 {
     -webkit-animation-delay: -1s;
             animation-delay: -1s; }
-  .sk-wave .sk-rect4 {
+  .sk.sk-wave .sk-rect4 {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
-  .sk-wave .sk-rect5 {
+  .sk.sk-wave .sk-rect5 {
     -webkit-animation-delay: -0.8s;
             animation-delay: -0.8s; }
 
@@ -65,7 +173,7 @@
 <body>
  
 
-      <div class="sk-wave">
+      <div class="sk sk-wave">
         <div class="sk-rect sk-rect1"></div>
         <div class="sk-rect sk-rect2"></div>
         <div class="sk-rect sk-rect3"></div>

--- a/examples/4-wandering-cubes.html
+++ b/examples/4-wandering-cubes.html
@@ -6,18 +6,101 @@
     /*
  *  Usage:
  *
-      <div class="sk-wandering-cubes">
+      <div class="sk sk-wandering-cubes">
         <div class="sk-cube sk-cube1"></div>
         <div class="sk-cube sk-cube2"></div>
       </div>
  *
  */
-.sk-wandering-cubes {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-wandering-cubes {
   position: relative; }
-  .sk-wandering-cubes .sk-cube {
+  .sk.sk-wandering-cubes .sk-cube {
     background-color: #333;
     width: 10px;
     height: 10px;
@@ -26,9 +109,24 @@
     left: 0;
     -webkit-animation: sk-wanderingCube 1.8s ease-in-out -1.8s infinite both;
             animation: sk-wanderingCube 1.8s ease-in-out -1.8s infinite both; }
-  .sk-wandering-cubes .sk-cube2 {
+  .sk.sk-wandering-cubes .sk-cube2 {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
+  .sk.sk-wandering-cubes.sk-xs-width, .sk.sk-wandering-cubes.sk-xs {
+    width: 2.5px;
+    height: 2.5px; }
+  .sk.sk-wandering-cubes.sk-sm-width, .sk.sk-wandering-cubes.sk-sm {
+    width: 5px;
+    height: 5px; }
+  .sk.sk-wandering-cubes.sk-md-width, .sk.sk-wandering-cubes.sk-md {
+    width: 10px;
+    height: 10px; }
+  .sk.sk-wandering-cubes.sk-lg-width, .sk.sk-wandering-cubes.sk-lg {
+    width: 15px;
+    height: 15px; }
+  .sk.sk-wandering-cubes.sk-xl-width, .sk.sk-wandering-cubes.sk-xl {
+    width: 25px;
+    height: 25px; }
 
 @-webkit-keyframes sk-wanderingCube {
   0% {
@@ -77,7 +175,7 @@
 <body>
  
 
-      <div class="sk-wandering-cubes">
+      <div class="sk sk-wandering-cubes">
         <div class="sk-cube sk-cube1"></div>
         <div class="sk-cube sk-cube2"></div>
       </div>

--- a/examples/5-pulse.html
+++ b/examples/5-pulse.html
@@ -6,17 +6,100 @@
     /*
  *  Usage:
  *
-      <div class="sk-spinner sk-spinner-pulse"></div>
+      <div class="sk sk-pulse"></div>
  *
  */
-.sk-spinner-pulse {
-  width: 40px;
-  height: 40px;
-  margin: 40px auto;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-pulse {
   background-color: #333;
   border-radius: 100%;
-  -webkit-animation: sk-pulseScaleOut 1s infinite ease-in-out;
-          animation: sk-pulseScaleOut 1s infinite ease-in-out; }
+  -webkit-animation: sk-pulseScaleOut 1.0s infinite ease-in-out;
+          animation: sk-pulseScaleOut 1.0s infinite ease-in-out; }
 
 @-webkit-keyframes sk-pulseScaleOut {
   0% {
@@ -41,6 +124,6 @@
 <body>
  
 
-      <div class="sk-spinner sk-spinner-pulse"></div>
+      <div class="sk sk-pulse"></div>
 </body>
 </html>

--- a/examples/6-chasing-dots.html
+++ b/examples/6-chasing-dots.html
@@ -6,21 +6,104 @@
     /*
  *  Usage:
  *
-      <div class="sk-chasing-dots">
+      <div class="sk sk-chasing-dots">
         <div class="sk-child sk-dot1"></div>
         <div class="sk-child sk-dot2"></div>
       </div>
  *
  */
-.sk-chasing-dots {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-chasing-dots {
   position: relative;
   text-align: center;
   -webkit-animation: sk-chasingDotsRotate 2s infinite linear;
           animation: sk-chasingDotsRotate 2s infinite linear; }
-  .sk-chasing-dots .sk-child {
+  .sk.sk-chasing-dots .sk-child {
     width: 60%;
     height: 60%;
     display: inline-block;
@@ -30,7 +113,7 @@
     border-radius: 100%;
     -webkit-animation: sk-chasingDotsBounce 2s infinite ease-in-out;
             animation: sk-chasingDotsBounce 2s infinite ease-in-out; }
-  .sk-chasing-dots .sk-dot2 {
+  .sk.sk-chasing-dots .sk-dot2 {
     top: auto;
     bottom: 0;
     -webkit-animation-delay: -1s;
@@ -67,7 +150,7 @@
 <body>
  
 
-      <div class="sk-chasing-dots">
+      <div class="sk sk-chasing-dots">
         <div class="sk-child sk-dot1"></div>
         <div class="sk-child sk-dot2"></div>
       </div>

--- a/examples/7-three-bounce.html
+++ b/examples/7-three-bounce.html
@@ -6,18 +6,103 @@
     /*
  *  Usage:
  *
-      <div class="sk-three-bounce">
+      <div class="sk sk-three-bounce">
         <div class="sk-child sk-bounce1"></div>
         <div class="sk-child sk-bounce2"></div>
         <div class="sk-child sk-bounce3"></div>
       </div>
  *
  */
-.sk-three-bounce {
-  margin: 40px auto;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-three-bounce {
   width: 80px;
   text-align: center; }
-  .sk-three-bounce .sk-child {
+  .sk.sk-three-bounce .sk-child {
     width: 20px;
     height: 20px;
     background-color: #333;
@@ -25,10 +110,35 @@
     display: inline-block;
     -webkit-animation: sk-three-bounce 1.4s ease-in-out 0s infinite both;
             animation: sk-three-bounce 1.4s ease-in-out 0s infinite both; }
-  .sk-three-bounce .sk-bounce1 {
+  .sk.sk-three-bounce.sk-xs-width, .sk.sk-three-bounce.sk-xs {
+    width: 25px; }
+    .sk.sk-three-bounce.sk-xs-width .sk-child, .sk.sk-three-bounce.sk-xs .sk-child {
+      width: 4px;
+      height: 4px; }
+  .sk.sk-three-bounce.sk-sm-width, .sk.sk-three-bounce.sk-sm {
+    width: 40px; }
+    .sk.sk-three-bounce.sk-sm-width .sk-child, .sk.sk-three-bounce.sk-sm .sk-child {
+      width: 10px;
+      height: 10px; }
+  .sk.sk-three-bounce.sk-md-width, .sk.sk-three-bounce.sk-md {
+    width: 80px; }
+    .sk.sk-three-bounce.sk-md-width .sk-child, .sk.sk-three-bounce.sk-md .sk-child {
+      width: 20px;
+      height: 20px; }
+  .sk.sk-three-bounce.sk-lg-width, .sk.sk-three-bounce.sk-lg {
+    width: 120px; }
+    .sk.sk-three-bounce.sk-lg-width .sk-child, .sk.sk-three-bounce.sk-lg .sk-child {
+      width: 30px;
+      height: 30px; }
+  .sk.sk-three-bounce.sk-xl-width, .sk.sk-three-bounce.sk-xl {
+    width: 200px; }
+    .sk.sk-three-bounce.sk-xl-width .sk-child, .sk.sk-three-bounce.sk-xl .sk-child {
+      width: 50px;
+      height: 50px; }
+  .sk.sk-three-bounce .sk-bounce1 {
     -webkit-animation-delay: -0.32s;
             animation-delay: -0.32s; }
-  .sk-three-bounce .sk-bounce2 {
+  .sk.sk-three-bounce .sk-bounce2 {
     -webkit-animation-delay: -0.16s;
             animation-delay: -0.16s; }
 
@@ -53,7 +163,7 @@
 <body>
  
 
-      <div class="sk-three-bounce">
+      <div class="sk sk-three-bounce">
         <div class="sk-child sk-bounce1"></div>
         <div class="sk-child sk-bounce2"></div>
         <div class="sk-child sk-bounce3"></div>

--- a/examples/8-circle.html
+++ b/examples/8-circle.html
@@ -6,7 +6,7 @@
     /*
  *  Usage:
  *
-      <div class="sk-circle">
+      <div class="sk sk-circle">
         <div class="sk-circle1 sk-child"></div>
         <div class="sk-circle2 sk-child"></div>
         <div class="sk-circle3 sk-child"></div>
@@ -22,18 +22,101 @@
       </div>
  *
  */
-.sk-circle {
-  margin: 40px auto;
-  width: 40px;
-  height: 40px;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-circle {
   position: relative; }
-  .sk-circle .sk-child {
+  .sk.sk-circle .sk-child {
     width: 100%;
     height: 100%;
     position: absolute;
     left: 0;
     top: 0; }
-  .sk-circle .sk-child:before {
+  .sk.sk-circle .sk-child:before {
     content: '';
     display: block;
     margin: 0 auto;
@@ -43,81 +126,81 @@
     border-radius: 100%;
     -webkit-animation: sk-circleBounceDelay 1.2s infinite ease-in-out both;
             animation: sk-circleBounceDelay 1.2s infinite ease-in-out both; }
-  .sk-circle .sk-circle2 {
+  .sk.sk-circle .sk-circle2 {
     -webkit-transform: rotate(30deg);
         -ms-transform: rotate(30deg);
             transform: rotate(30deg); }
-  .sk-circle .sk-circle3 {
+  .sk.sk-circle .sk-circle3 {
     -webkit-transform: rotate(60deg);
         -ms-transform: rotate(60deg);
             transform: rotate(60deg); }
-  .sk-circle .sk-circle4 {
+  .sk.sk-circle .sk-circle4 {
     -webkit-transform: rotate(90deg);
         -ms-transform: rotate(90deg);
             transform: rotate(90deg); }
-  .sk-circle .sk-circle5 {
+  .sk.sk-circle .sk-circle5 {
     -webkit-transform: rotate(120deg);
         -ms-transform: rotate(120deg);
             transform: rotate(120deg); }
-  .sk-circle .sk-circle6 {
+  .sk.sk-circle .sk-circle6 {
     -webkit-transform: rotate(150deg);
         -ms-transform: rotate(150deg);
             transform: rotate(150deg); }
-  .sk-circle .sk-circle7 {
+  .sk.sk-circle .sk-circle7 {
     -webkit-transform: rotate(180deg);
         -ms-transform: rotate(180deg);
             transform: rotate(180deg); }
-  .sk-circle .sk-circle8 {
+  .sk.sk-circle .sk-circle8 {
     -webkit-transform: rotate(210deg);
         -ms-transform: rotate(210deg);
             transform: rotate(210deg); }
-  .sk-circle .sk-circle9 {
+  .sk.sk-circle .sk-circle9 {
     -webkit-transform: rotate(240deg);
         -ms-transform: rotate(240deg);
             transform: rotate(240deg); }
-  .sk-circle .sk-circle10 {
+  .sk.sk-circle .sk-circle10 {
     -webkit-transform: rotate(270deg);
         -ms-transform: rotate(270deg);
             transform: rotate(270deg); }
-  .sk-circle .sk-circle11 {
+  .sk.sk-circle .sk-circle11 {
     -webkit-transform: rotate(300deg);
         -ms-transform: rotate(300deg);
             transform: rotate(300deg); }
-  .sk-circle .sk-circle12 {
+  .sk.sk-circle .sk-circle12 {
     -webkit-transform: rotate(330deg);
         -ms-transform: rotate(330deg);
             transform: rotate(330deg); }
-  .sk-circle .sk-circle2:before {
+  .sk.sk-circle .sk-circle2:before {
     -webkit-animation-delay: -1.1s;
             animation-delay: -1.1s; }
-  .sk-circle .sk-circle3:before {
+  .sk.sk-circle .sk-circle3:before {
     -webkit-animation-delay: -1s;
             animation-delay: -1s; }
-  .sk-circle .sk-circle4:before {
+  .sk.sk-circle .sk-circle4:before {
     -webkit-animation-delay: -0.9s;
             animation-delay: -0.9s; }
-  .sk-circle .sk-circle5:before {
+  .sk.sk-circle .sk-circle5:before {
     -webkit-animation-delay: -0.8s;
             animation-delay: -0.8s; }
-  .sk-circle .sk-circle6:before {
+  .sk.sk-circle .sk-circle6:before {
     -webkit-animation-delay: -0.7s;
             animation-delay: -0.7s; }
-  .sk-circle .sk-circle7:before {
+  .sk.sk-circle .sk-circle7:before {
     -webkit-animation-delay: -0.6s;
             animation-delay: -0.6s; }
-  .sk-circle .sk-circle8:before {
+  .sk.sk-circle .sk-circle8:before {
     -webkit-animation-delay: -0.5s;
             animation-delay: -0.5s; }
-  .sk-circle .sk-circle9:before {
+  .sk.sk-circle .sk-circle9:before {
     -webkit-animation-delay: -0.4s;
             animation-delay: -0.4s; }
-  .sk-circle .sk-circle10:before {
+  .sk.sk-circle .sk-circle10:before {
     -webkit-animation-delay: -0.3s;
             animation-delay: -0.3s; }
-  .sk-circle .sk-circle11:before {
+  .sk.sk-circle .sk-circle11:before {
     -webkit-animation-delay: -0.2s;
             animation-delay: -0.2s; }
-  .sk-circle .sk-circle12:before {
+  .sk.sk-circle .sk-circle12:before {
     -webkit-animation-delay: -0.1s;
             animation-delay: -0.1s; }
 
@@ -142,7 +225,7 @@
 <body>
  
 
-      <div class="sk-circle">
+      <div class="sk sk-circle">
         <div class="sk-circle1 sk-child"></div>
         <div class="sk-circle2 sk-child"></div>
         <div class="sk-circle3 sk-child"></div>

--- a/examples/9-cube-grid.html
+++ b/examples/9-cube-grid.html
@@ -6,7 +6,7 @@
     /*
  *  Usage:
  *
-      <div class="sk-cube-grid">
+      <div class="sk sk-cube-grid">
         <div class="sk-cube sk-cube1"></div>
         <div class="sk-cube sk-cube2"></div>
         <div class="sk-cube sk-cube3"></div>
@@ -19,48 +19,131 @@
       </div>
  *
  */
-.sk-cube-grid {
-  width: 40px;
-  height: 40px;
-  margin: 40px auto;
+.sk {
+  vertical-align: middle;
+  display: inline-block; }
+  .sk.sk-default-width, .sk, .sk.sk-default {
+    width: 40px; }
+  .sk.sk-xs-width, .sk.sk-xs {
+    width: 10px; }
+  .sk.sk-sm-width, .sk.sk-sm {
+    width: 20px; }
+  .sk.sk-md-width, .sk.sk-md {
+    width: 40px; }
+  .sk.sk-lg-width, .sk.sk-lg {
+    width: 60px; }
+  .sk.sk-xl-width, .sk.sk-xl {
+    width: 100px; }
+  .sk.sk-default-height, .sk, .sk.sk-default {
+    height: 40px; }
+  .sk.sk-xs-height, .sk.sk-xs {
+    height: 10px; }
+  .sk.sk-sm-height, .sk.sk-sm {
+    height: 20px; }
+  .sk.sk-md-height, .sk.sk-md {
+    height: 40px; }
+  .sk.sk-lg-height, .sk.sk-lg {
+    height: 60px; }
+  .sk.sk-xl-height, .sk.sk-xl {
+    height: 100px; }
+  .sk.sk-no-margin {
+    margin: 0; }
+  .sk.sk-auto-margin {
+    margin: auto;
+    display: block; }
+  .sk.sk-xs-margin {
+    margin: 10px; }
+  .sk.sk-sm-margin {
+    margin: 20px; }
+  .sk.sk-md-margin {
+    margin: 40px; }
+  .sk.sk-lg-margin {
+    margin: 60px; }
+  .sk.sk-xl-margin {
+    margin: 100px; }
+  .sk.sk-no-vmargin, .sk {
+    margin-top: 0;
+    margin-bottom: 0; }
+  .sk.sk-auto-vmargin {
+    margin-top: auto;
+    margin-bottom: auto; }
+  .sk.sk-xs-vmargin {
+    margin-top: 10px;
+    margin-bottom: 10px; }
+  .sk.sk-sm-vmargin {
+    margin-top: 20px;
+    margin-bottom: 20px; }
+  .sk.sk-md-vmargin {
+    margin-top: 40px;
+    margin-bottom: 40px; }
+  .sk.sk-lg-vmargin {
+    margin-top: 60px;
+    margin-bottom: 60px; }
+  .sk.sk-xl-vmargin {
+    margin-top: 100px;
+    margin-bottom: 100px; }
+  .sk.sk-no-hmargin, .sk {
+    margin-left: 0;
+    margin-right: 0; }
+  .sk.sk-auto-hmargin {
+    margin-left: auto;
+    margin-right: auto;
+    display: block; }
+  .sk.sk-xs-hmargin {
+    margin-left: 10px;
+    margin-right: 10px; }
+  .sk.sk-sm-hmargin {
+    margin-left: 20px;
+    margin-right: 20px; }
+  .sk.sk-md-hmargin {
+    margin-left: 40px;
+    margin-right: 40px; }
+  .sk.sk-lg-hmargin {
+    margin-left: 60px;
+    margin-right: 60px; }
+  .sk.sk-xl-hmargin {
+    margin-left: 100px;
+    margin-right: 100px; }
+
+.sk.sk-cube-grid {
   /*
    * Spinner positions
    * 1 2 3
    * 4 5 6
    * 7 8 9
    */ }
-  .sk-cube-grid .sk-cube {
+  .sk.sk-cube-grid .sk-cube {
     width: 33.33%;
     height: 33.33%;
     background-color: #333;
     float: left;
     -webkit-animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
             animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out; }
-  .sk-cube-grid .sk-cube1 {
+  .sk.sk-cube-grid .sk-cube1 {
     -webkit-animation-delay: 0.2s;
             animation-delay: 0.2s; }
-  .sk-cube-grid .sk-cube2 {
+  .sk.sk-cube-grid .sk-cube2 {
     -webkit-animation-delay: 0.3s;
             animation-delay: 0.3s; }
-  .sk-cube-grid .sk-cube3 {
+  .sk.sk-cube-grid .sk-cube3 {
     -webkit-animation-delay: 0.4s;
             animation-delay: 0.4s; }
-  .sk-cube-grid .sk-cube4 {
+  .sk.sk-cube-grid .sk-cube4 {
     -webkit-animation-delay: 0.1s;
             animation-delay: 0.1s; }
-  .sk-cube-grid .sk-cube5 {
+  .sk.sk-cube-grid .sk-cube5 {
     -webkit-animation-delay: 0.2s;
             animation-delay: 0.2s; }
-  .sk-cube-grid .sk-cube6 {
+  .sk.sk-cube-grid .sk-cube6 {
     -webkit-animation-delay: 0.3s;
             animation-delay: 0.3s; }
-  .sk-cube-grid .sk-cube7 {
+  .sk.sk-cube-grid .sk-cube7 {
     -webkit-animation-delay: 0.0s;
             animation-delay: 0.0s; }
-  .sk-cube-grid .sk-cube8 {
+  .sk.sk-cube-grid .sk-cube8 {
     -webkit-animation-delay: 0.1s;
             animation-delay: 0.1s; }
-  .sk-cube-grid .sk-cube9 {
+  .sk.sk-cube-grid .sk-cube9 {
     -webkit-animation-delay: 0.2s;
             animation-delay: 0.2s; }
 
@@ -85,7 +168,7 @@
 <body>
  
 
-      <div class="sk-cube-grid">
+      <div class="sk sk-cube-grid">
         <div class="sk-cube sk-cube1"></div>
         <div class="sk-cube sk-cube2"></div>
         <div class="sk-cube sk-cube3"></div>

--- a/scss/_base.scss
+++ b/scss/_base.scss
@@ -1,0 +1,100 @@
+@import "./variables";
+
+.sk {
+    vertical-align: $sk-vertical-align;
+    display: $sk-display;
+    @extend .sk-default-width;
+    @extend .sk-default-height;
+    @extend .sk-no-vmargin;
+    @extend .sk-no-hmargin;
+
+    &.sk-default-width { width: $sk-default-size }
+    &.sk-xs-width { width: $sk-xs-size }
+    &.sk-sm-width { width: $sk-sm-size }
+    &.sk-md-width { width: $sk-md-size }
+    &.sk-lg-width { width: $sk-lg-size }
+    &.sk-xl-width { width: $sk-xl-size }
+
+    &.sk-default-height { height: $sk-default-size }
+    &.sk-xs-height { height: $sk-xs-size }
+    &.sk-sm-height { height: $sk-sm-size }
+    &.sk-md-height { height: $sk-md-size }
+    &.sk-lg-height { height: $sk-lg-size }
+    &.sk-xl-height { height: $sk-xl-size }
+
+    &.sk-default { @extend .sk-default-width; @extend .sk-default-height }
+    &.sk-xs { @extend .sk-xs-width; @extend .sk-xs-height }
+    &.sk-sm { @extend .sk-sm-width; @extend .sk-sm-height }
+    &.sk-md { @extend .sk-md-width; @extend .sk-md-height }
+    &.sk-lg { @extend .sk-lg-width; @extend .sk-lg-height }
+    &.sk-xl { @extend .sk-xl-width; @extend .sk-xl-height }
+
+    &.sk-no-margin { margin: $sk-no-margin }
+    // Force "block" to allow the spinner to be centered in its container.
+    &.sk-auto-margin { margin: $sk-auto-margin; display: block }
+    &.sk-xs-margin { margin: $sk-xs-margin }
+    &.sk-sm-margin { margin: $sk-sm-margin }
+    &.sk-md-margin { margin: $sk-md-margin }
+    &.sk-lg-margin { margin: $sk-lg-margin }
+    &.sk-xl-margin { margin: $sk-xl-margin }
+
+    &.sk-no-vmargin {
+      margin-top: $sk-no-margin;
+      margin-bottom: $sk-no-margin;
+    }
+    &.sk-auto-vmargin {
+      margin-top: $sk-auto-margin;
+      margin-bottom: $sk-auto-margin;
+    }
+    &.sk-xs-vmargin {
+      margin-top: $sk-xs-margin;
+      margin-bottom: $sk-xs-margin;
+    }
+    &.sk-sm-vmargin {
+      margin-top: $sk-sm-margin;
+      margin-bottom: $sk-sm-margin;
+    }
+    &.sk-md-vmargin {
+      margin-top: $sk-md-margin;
+      margin-bottom: $sk-md-margin;
+    }
+    &.sk-lg-vmargin {
+      margin-top: $sk-lg-margin;
+      margin-bottom: $sk-lg-margin;
+    }
+    &.sk-xl-vmargin {
+      margin-top: $sk-xl-margin;
+      margin-bottom: $sk-xl-margin;
+    }
+
+    &.sk-no-hmargin {
+      margin-left: $sk-no-margin;
+      margin-right: $sk-no-margin;
+    }
+    &.sk-auto-hmargin {
+      margin-left: $sk-auto-margin;
+      margin-right: $sk-auto-margin;
+      // Force "block" to allow the spinner to be centered in its container.
+      display: block;
+    }
+    &.sk-xs-hmargin {
+      margin-left: $sk-xs-margin;
+      margin-right: $sk-xs-margin;
+    }
+    &.sk-sm-hmargin {
+      margin-left: $sk-sm-margin;
+      margin-right: $sk-sm-margin;
+    }
+    &.sk-md-hmargin {
+      margin-left: $sk-md-margin;
+      margin-right: $sk-md-margin;
+    }
+    &.sk-lg-hmargin {
+      margin-left: $sk-lg-margin;
+      margin-right: $sk-lg-margin;
+    }
+    &.sk-xl-hmargin {
+      margin-left: $sk-xl-margin;
+      margin-right: $sk-xl-margin;
+    }
+}

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -1,3 +1,19 @@
-$spinkit-spinner-margin: 40px auto !default;
-$spinkit-size: 40px !default;
-$spinkit-spinner-color: #333 !default;
+$sk-vertical-align: middle !default;
+$sk-display: inline-block !default;
+
+$sk-xs-size: 10px !default;
+$sk-sm-size: 20px !default;
+$sk-md-size: 40px !default;
+$sk-lg-size: 60px !default;
+$sk-xl-size: 100px !default;
+$sk-default-size: $sk-md-size !default;
+
+$sk-no-margin: 0 !default;
+$sk-auto-margin: auto !default;
+$sk-xs-margin: 10px !default;
+$sk-sm-margin: 20px !default;
+$sk-md-margin: 40px !default;
+$sk-lg-margin: 60px !default;
+$sk-xl-margin: 100px !default;
+
+$sk-spinner-color: #333 !default;

--- a/scss/spinkit.scss
+++ b/scss/spinkit.scss
@@ -1,12 +1,12 @@
 @import
-  "spinners/1-rotating-plane",
-  "spinners/2-double-bounce",
-  "spinners/3-wave",
-  "spinners/4-wandering-cubes",
-  "spinners/5-pulse",
-  "spinners/6-chasing-dots",
-  "spinners/7-three-bounce",
-  "spinners/8-circle",
-  "spinners/9-cube-grid",
-  "spinners/10-fading-circle",
-  "spinners/11-folding-cube";
+  "./spinners/1-rotating-plane",
+  "./spinners/2-double-bounce",
+  "./spinners/3-wave",
+  "./spinners/4-wandering-cubes",
+  "./spinners/5-pulse",
+  "./spinners/6-chasing-dots",
+  "./spinners/7-three-bounce",
+  "./spinners/8-circle",
+  "./spinners/9-cube-grid",
+  "./spinners/10-fading-circle",
+  "./spinners/11-folding-cube";

--- a/scss/spinners/1-rotating-plane.scss
+++ b/scss/spinners/1-rotating-plane.scss
@@ -1,16 +1,13 @@
 /*
  *  Usage:
  *
-      <div class="sk-rotating-plane"></div>
+      <div class="sk sk-rotating-plane"></div>
  *
  */
-@import "../variables";
+@import "../base";
 
-.sk-rotating-plane {
-  width: $spinkit-size;
-  height: $spinkit-size;
-  background-color: $spinkit-spinner-color;
-  margin: $spinkit-spinner-margin;
+.sk.sk-rotating-plane {
+  background-color: $sk-spinner-color;
   animation: sk-rotatePlane 1.2s infinite ease-in-out;
 }
 

--- a/scss/spinners/10-fading-circle.scss
+++ b/scss/spinners/10-fading-circle.scss
@@ -1,7 +1,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-fading-circle">
+      <div class="sk sk-fading-circle">
         <div class="sk-circle1 sk-circle"></div>
         <div class="sk-circle2 sk-circle"></div>
         <div class="sk-circle3 sk-circle"></div>
@@ -17,15 +17,13 @@
       </div>
  *
  */
-@import "../variables";
+@import "../base";
 
-.sk-fading-circle {
+.sk.sk-fading-circle {
+
   $circleCount: 12;
   $animationDuration: 1.2s;
 
-  margin: $spinkit-spinner-margin;
-  width: $spinkit-size;
-  height: $spinkit-size;
   position: relative;
 
   .sk-circle {
@@ -42,7 +40,7 @@
     margin: 0 auto;
     width: 15%;
     height: 15%;
-    background-color: $spinkit-spinner-color;
+    background-color: $sk-spinner-color;
     border-radius: 100%;
     animation: sk-circleFadeDelay $animationDuration infinite ease-in-out both;
   }

--- a/scss/spinners/11-folding-cube.scss
+++ b/scss/spinners/11-folding-cube.scss
@@ -1,7 +1,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-folding-cube">
+      <div class="sk sk-folding-cube">
         <div class="sk-cube1 sk-cube"></div>
         <div class="sk-cube2 sk-cube"></div>
         <div class="sk-cube4 sk-cube"></div>
@@ -9,16 +9,14 @@
       </div>
  *
  */
-@import "../variables";
+@import "../base";
 
-.sk-folding-cube {
+.sk.sk-folding-cube {
+
   $cubeCount: 4;
   $animationDuration: 2.4s;
   $delayRange: $animationDuration/2;
 
-  margin: $spinkit-spinner-margin;
-  width: $spinkit-size;
-  height: $spinkit-size;
   position: relative;
   transform: rotateZ(45deg);
 
@@ -37,7 +35,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: $spinkit-spinner-color;
+    background-color: $sk-spinner-color;
     animation: sk-foldCubeAngle $animationDuration infinite linear both;
     transform-origin: 100% 100%;
   }

--- a/scss/spinners/2-double-bounce.scss
+++ b/scss/spinners/2-double-bounce.scss
@@ -1,25 +1,23 @@
 /*
  *  Usage:
  *
-      <div class="sk-double-bounce">
+      <div class="sk sk-double-bounce">
         <div class="sk-child sk-double-bounce1"></div>
         <div class="sk-child sk-double-bounce2"></div>
       </div>
  *
  */
-@import "../variables";
+@import "../base";
 
-.sk-double-bounce {
-  width: $spinkit-size;
-  height: $spinkit-size;
+.sk.sk-double-bounce {
+
   position: relative;
-  margin: $spinkit-spinner-margin;
 
   .sk-child {
     width: 100%;
     height: 100%;
     border-radius: 50%;
-    background-color: $spinkit-spinner-color;
+    background-color: $sk-spinner-color;
     opacity: 0.6;
     position: absolute;
     top: 0;

--- a/scss/spinners/3-wave.scss
+++ b/scss/spinners/3-wave.scss
@@ -1,7 +1,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-wave">
+      <div class="sk sk-wave">
         <div class="sk-rect sk-rect1"></div>
         <div class="sk-rect sk-rect2"></div>
         <div class="sk-rect sk-rect3"></div>
@@ -10,25 +10,49 @@
       </div>
  *
  */
-@import "../variables";
+@import "../base";
 
-.sk-wave {
+.sk.sk-wave {
+
   $rectCount: 5;
   $animationDuration: 1.2s;
   $delayRange: 0.4s;
 
-  margin: $spinkit-spinner-margin;
-  width: $spinkit-size * 1.25;
-  height: $spinkit-size;
   text-align: center;
-  font-size: 10px;
+  font-size: $sk-default-size / 4;
 
   .sk-rect {
-    background-color: $spinkit-spinner-color;
+    background-color: $sk-spinner-color;
     height: 100%;
-    width: 6px;
+    width: $sk-default-size * 0.15;
     display: inline-block;
     animation: sk-waveStretchDelay $animationDuration infinite ease-in-out;
+  }
+
+  &.sk-xs-width {
+    width: $sk-xs-size * 1.25;
+    font-size: $sk-xs-size / 4;
+    & .sk-rect { width: $sk-xs-size * 0.15 }
+  }
+  &.sk-sm-width {
+    width: $sk-sm-size * 1.25;
+    font-size: $sk-sm-size / 4;
+    & .sk-rect { width: $sk-sm-size * 0.15 }
+  }
+  &.sk-md-width {
+    width: $sk-md-size * 1.25;
+    font-size: $sk-md-size / 4;
+    & .sk-rect { width: $sk-md-size * 0.15 }
+  }
+  &.sk-lg-width {
+    width: $sk-lg-size * 1.25;
+    font-size: $sk-lg-size / 4;
+    & .sk-rect { width: $sk-lg-size * 0.15 }
+  }
+  &.sk-xl-width {
+    width: $sk-xl-size * 1.25;
+    font-size: $sk-xl-size / 4;
+    & .sk-rect { width: $sk-xl-size * 0.15 }
   }
 
   @for $i from 1 through $rectCount {

--- a/scss/spinners/4-wandering-cubes.scss
+++ b/scss/spinners/4-wandering-cubes.scss
@@ -1,26 +1,23 @@
 /*
  *  Usage:
  *
-      <div class="sk-wandering-cubes">
+      <div class="sk sk-wandering-cubes">
         <div class="sk-cube sk-cube1"></div>
         <div class="sk-cube sk-cube2"></div>
       </div>
  *
  */
-@import "../variables";
+@import "../base";
 
-.sk-wandering-cubes {
+.sk.sk-wandering-cubes {
   $animationDuration: 1.8s;
 
-  margin: $spinkit-spinner-margin;
-  width: $spinkit-size;
-  height: $spinkit-size;
   position: relative;
 
   .sk-cube {
-    background-color: $spinkit-spinner-color;
-    width: 10px;
-    height: 10px;
+    background-color: $sk-spinner-color;
+    width: $sk-default-size / 4;
+    height: $sk-default-size / 4;
     position: absolute;
     top: 0;
     left: 0;
@@ -30,6 +27,12 @@
   .sk-cube2 {
     animation-delay: -$animationDuration / 2;
   }
+
+  &.sk-xs-width { width: $sk-xs-size / 4; height: $sk-xs-size / 4 }
+  &.sk-sm-width { width: $sk-sm-size / 4; height: $sk-sm-size / 4 }
+  &.sk-md-width { width: $sk-md-size / 4; height: $sk-md-size / 4 }
+  &.sk-lg-width { width: $sk-lg-size / 4; height: $sk-lg-size / 4 }
+  &.sk-xl-width { width: $sk-xl-size / 4; height: $sk-xl-size / 4 }
 }
 
 @keyframes sk-wanderingCube {

--- a/scss/spinners/5-pulse.scss
+++ b/scss/spinners/5-pulse.scss
@@ -1,16 +1,14 @@
 /*
  *  Usage:
  *
-      <div class="sk-spinner sk-spinner-pulse"></div>
+      <div class="sk sk-pulse"></div>
  *
  */
-@import "../variables";
+@import "../base";
 
-.sk-spinner-pulse {
-  width: $spinkit-size;
-  height: $spinkit-size;
-  margin: $spinkit-spinner-margin;
-  background-color: $spinkit-spinner-color;
+.sk.sk-pulse {
+
+  background-color: $sk-spinner-color;
   border-radius: 100%;
   animation: sk-pulseScaleOut 1.0s infinite ease-in-out;
 }

--- a/scss/spinners/6-chasing-dots.scss
+++ b/scss/spinners/6-chasing-dots.scss
@@ -1,20 +1,18 @@
 /*
  *  Usage:
  *
-      <div class="sk-chasing-dots">
+      <div class="sk sk-chasing-dots">
         <div class="sk-child sk-dot1"></div>
         <div class="sk-child sk-dot2"></div>
       </div>
  *
  */
-@import "../variables";
+@import "../base";
 
-.sk-chasing-dots {
+.sk.sk-chasing-dots {
+
   $animationDuration: 2.0s;
 
-  margin: $spinkit-spinner-margin;
-  width: $spinkit-size;
-  height: $spinkit-size;
   position: relative;
   text-align: center;
   animation: sk-chasingDotsRotate $animationDuration infinite linear;
@@ -25,7 +23,7 @@
     display: inline-block;
     position: absolute;
     top: 0;
-    background-color: $spinkit-spinner-color;
+    background-color: $sk-spinner-color;
     border-radius: 100%;
     animation: sk-chasingDotsBounce $animationDuration infinite ease-in-out;
   }

--- a/scss/spinners/7-three-bounce.scss
+++ b/scss/spinners/7-three-bounce.scss
@@ -1,30 +1,52 @@
 /*
  *  Usage:
  *
-      <div class="sk-three-bounce">
+      <div class="sk sk-three-bounce">
         <div class="sk-child sk-bounce1"></div>
         <div class="sk-child sk-bounce2"></div>
         <div class="sk-child sk-bounce3"></div>
       </div>
  *
  */
- @import "../variables";
+ @import "../base";
 
-.sk-three-bounce {
+.sk.sk-three-bounce {
   $animationDuration: 1.4s;
   $delayRange: 0.32s;
-  margin: $spinkit-spinner-margin;
-  width: $spinkit-size * 2;
+  width: $sk-default-size * 2;
   text-align: center;
 
   .sk-child {
-    width: $spinkit-size / 2;
-    height: $spinkit-size / 2;
-    background-color: $spinkit-spinner-color;
+    width: $sk-default-size / 2;
+    height: $sk-default-size / 2;
+    background-color: $sk-spinner-color;
 
     border-radius: 100%;
     display: inline-block;
     animation: sk-three-bounce $animationDuration ease-in-out 0s infinite both;
+  }
+
+
+  &.sk-xs-width {
+    // Made smaller than the others to make border-radius behave
+    width: $sk-xs-size * 2.5;
+    .sk-child { width: $sk-xs-size / 2.5; height: $sk-xs-size / 2.5}
+  }
+  &.sk-sm-width {
+    width: $sk-sm-size * 2;
+    .sk-child { width: $sk-sm-size / 2; height: $sk-sm-size / 2}
+  }
+  &.sk-md-width {
+    width: $sk-md-size * 2;
+    .sk-child { width: $sk-md-size / 2; height: $sk-md-size / 2}
+  }
+  &.sk-lg-width {
+    width: $sk-lg-size * 2;
+    .sk-child { width: $sk-lg-size / 2; height: $sk-lg-size / 2}
+  }
+  &.sk-xl-width {
+    width: $sk-xl-size * 2;
+    .sk-child { width: $sk-xl-size / 2; height: $sk-xl-size / 2}
   }
 
   .sk-bounce1 { animation-delay: -$delayRange; }

--- a/scss/spinners/8-circle.scss
+++ b/scss/spinners/8-circle.scss
@@ -1,7 +1,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-circle">
+      <div class="sk sk-circle">
         <div class="sk-circle1 sk-child"></div>
         <div class="sk-circle2 sk-child"></div>
         <div class="sk-circle3 sk-child"></div>
@@ -17,15 +17,13 @@
       </div>
  *
  */
-@import "../variables";
+@import "../base";
 
-.sk-circle {
+.sk.sk-circle {
+
   $circleCount: 12;
   $animationDuration: 1.2s;
 
-  margin: $spinkit-spinner-margin;
-  width: $spinkit-size;
-  height: $spinkit-size;
   position: relative;
 
   .sk-child {
@@ -42,7 +40,7 @@
     margin: 0 auto;
     width: 15%;
     height: 15%;
-    background-color: $spinkit-spinner-color;
+    background-color: $sk-spinner-color;
     border-radius: 100%;
     animation: sk-circleBounceDelay $animationDuration infinite ease-in-out both;
   }

--- a/scss/spinners/9-cube-grid.scss
+++ b/scss/spinners/9-cube-grid.scss
@@ -1,7 +1,7 @@
 /*
  *  Usage:
  *
-      <div class="sk-cube-grid">
+      <div class="sk sk-cube-grid">
         <div class="sk-cube sk-cube1"></div>
         <div class="sk-cube sk-cube2"></div>
         <div class="sk-cube sk-cube3"></div>
@@ -14,19 +14,15 @@
       </div>
  *
  */
-@import "../variables";
+@import "../base";
 
-.sk-cube-grid {
+.sk.sk-cube-grid {
   $delayRange: 0.4s;
-
-  width: $spinkit-size;
-  height: $spinkit-size;
-  margin: $spinkit-spinner-margin;
 
   .sk-cube {
     width: 33.33%;
     height: 33.33%;
-    background-color: $spinkit-spinner-color;
+    background-color: $sk-spinner-color;
     float: left;
     animation: sk-cubeGridScaleDelay 1.3s infinite ease-in-out;
   }


### PR DESCRIPTION
Examples:

``` html
<!-- Extra small (10px) -->
<div class="sk sk-rotating-plane sk-xs"></div>

<!-- Small (20px) -->
<div class="sk sk-rotating-plane sk-sm"></div>

<!-- Medium (same as old default size, 40px) -->
<div class="sk sk-rotating-plane sk-md"></div>

<!-- Large (60px) -->
<div class="sk sk-rotating-plane sk-lg"></div>

<!-- Extra large (100px) -->
<div class="sk sk-rotating-plane sk-xl"></div>

<!-- Same margins as before this PR -->
<div class="sk sk-rotating-plane sk-auto-hmargin sk-md-vmargin"></div>
```

There are some breaking changes that allow us to decrease code duplication:
- The class “sk” has to be added to each spinner
- No margin is added to the spinner by default. The classes `sk-auto-hmargin` and `sk-md-vmargin` can be added to revert to the margins used before this PR.
- Renamed `sk-spinner-pulse` to `sk-pulse` to follow naming convention.
- Default to `display: inline-block` and `vertical-align: middle` for a more useful default

All spinners work great to resize except for `4-wandering-cubes`. This is because an absolute size is declared in its keyframe. It would be awesome if anyone could help me come up with a solution to this issue 😀
