### PR TITLE
Expose the Sass files themselves in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "loading",
     "ui"
   ],
-  "main": "gulpfile.js",
+  "main": "scss/spinkit.scss",
+  "style": "scss/spinkit.scss",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Enables importing them easily through the use of eg. https://www.npmjs.com/package/sass-module-importer

With that module one would simply do `@import "spinkit";` and get all of the files or do `@import "spinkit/scss/spinners/1-rotating-plane";` to import a specific spinner, all without having to know exactly where npm put the module, which if Spinkit is a sub-dependency of another package will be hard due to npm 3:s flattening of the dependency tree.
