### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.1
+
+* Fixed: Chase spinner's HTML snippet now has the correct number of children
+
 # 2.0.0
 
 * New: Added examples.html, with an overview of all spinners

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Tobias Ahlin
+Copyright (c) 2019 Tobias Ahlin
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spinkit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "A collection of loading indicators animated with CSS",
   "keywords": [
     "css",


### PR DESCRIPTION
Fixes the HTML snippet for the new "Chase" spinner containing too many children (dots) (HTML change is already in master)